### PR TITLE
support multiple languages based on MCF parameters (#33)

### DIFF
--- a/pygeometa/__init__.py
+++ b/pygeometa/__init__.py
@@ -62,6 +62,39 @@ TEMPLATES = '%s%stemplates' % (os.path.dirname(os.path.realpath(__file__)),
                                os.sep)
 
 
+def get_charstring(option, section_items, language,
+                   language_alternate=None):
+    """convenience function to return unilingual or multilingual value(s)"""
+
+    section_items = dict(section_items)
+    option_value1 = None
+    option_value2 = None
+
+    if 'language_alternate' is None:  # unilingual
+        option_tmp = '{}_{}'.format(option, language)
+        if option_tmp in section_items:
+            option_value1 = section_items[option_tmp]
+        else:
+            try:
+                option_value1 = section_items[option]
+            except KeyError:
+                pass  # default=None
+    else:  # multilingual
+        option_tmp = '{}_{}'.format(option, language)
+        if option_tmp in section_items:
+            option_value1 = section_items[option_tmp]
+        else:
+            try:
+                option_value1 = section_items[option]
+            except KeyError:
+                pass  # default=None
+        option_tmp2 = '{}_{}'.format(option, language_alternate)
+        if option_tmp2 in section_items:
+            option_value2 = section_items[option_tmp2]
+
+    return [option_value1, option_value2]
+
+
 def get_distribution_language(section):
     """derive language of a given distribution construct"""
 
@@ -148,10 +181,13 @@ def render_template(mcf, schema=None, schema_local=None):
         abspath = schema_local
 
     LOGGER.debug('Setting up template environment {}'.format(abspath))
-    env = Environment(loader=FileSystemLoader(abspath))
+    env = Environment(loader=FileSystemLoader([abspath, TEMPLATES]))
     env.filters['normalize_datestring'] = normalize_datestring
     env.filters['get_distribution_language'] = get_distribution_language
+    env.filters['get_charstring'] = get_charstring
     env.globals.update(zip=zip)
+    env.globals.update(get_charstring=get_charstring)
+    env.globals.update(normalize_datestring=normalize_datestring)
 
     try:
         LOGGER.debug('Loading template')

--- a/pygeometa/templates/common/iso19139-charstring.j2
+++ b/pygeometa/templates/common/iso19139-charstring.j2
@@ -1,0 +1,16 @@
+{% macro get_freetext(element, language_alternate, myvars) -%}
+{% if language_alternate is none or myvars[1] is none %}
+      <gmd:{{ element }}>
+        <gco:CharacterString>{{ myvars[0]|trim|e }}</gco:CharacterString>
+      </gmd:{{ element }}>
+{% else %}
+      <gmd:{{ element }} xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>{{ myvars[0]|trim|e }}</gco:CharacterString>
+          <gmd:PT_FreeText>
+            <gmd:textGroup>
+              <gmd:LocalisedCharacterString locale="#locale-{{ language_alternate }}">{{ myvars[1]|trim|e }}</gmd:LocalisedCharacterString>
+            </gmd:textGroup>
+          </gmd:PT_FreeText>
+      </gmd:{{ element }}>
+{% endif %}
+{% endmacro %}

--- a/pygeometa/templates/iso19139-hnap/contact.j2
+++ b/pygeometa/templates/iso19139-hnap/contact.j2
@@ -1,23 +1,7 @@
 <gmd:CI_ResponsibleParty>
-  <gmd:individualName>
-    <gco:CharacterString>{{ contact['individualname']|e }}</gco:CharacterString>
-  </gmd:individualName>
-  <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
-    <gco:CharacterString>{{ contact['organization_en']|e }}</gco:CharacterString>
-    <gmd:PT_FreeText>
-      <gmd:textGroup>
-        <gmd:LocalisedCharacterString locale="#fra">{{ contact['organization_fr']|e }}</gmd:LocalisedCharacterString>
-      </gmd:textGroup>
-    </gmd:PT_FreeText>
-  </gmd:organisationName>
-  <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
-    <gco:CharacterString>{{ contact['positionname_en']|e }}</gco:CharacterString>
-    <gmd:PT_FreeText>
-      <gmd:textGroup>
-        <gmd:LocalisedCharacterString locale="#fra">{{ contact['positionname_fr']|e }}</gmd:LocalisedCharacterString>
-      </gmd:textGroup>
-    </gmd:PT_FreeText>
-  </gmd:positionName>
+  {{ cs.get_freetext('individualName', 'fra', get_charstring('individualname', contact, 'en', 'fr')) }}
+  {{ cs.get_freetext('organisationName', 'fra', get_charstring('organization', contact, 'en', 'fr')) }}
+  {{ cs.get_freetext('positionName', 'fra', get_charstring('positionname', contact, 'en', 'fr')) }}
   <gmd:contactInfo>
     <gmd:CI_Contact>
       <gmd:phone>
@@ -40,29 +24,14 @@
       </gmd:phone>
       <gmd:address>
         <gmd:CI_Address>
-          <gmd:deliveryPoint>
-            <gco:CharacterString>{{ contact['address']|e }}</gco:CharacterString>
-          </gmd:deliveryPoint>
-          <gmd:deliveryPoint>
-            <gco:CharacterString>{{ contact['city']|e }}</gco:CharacterString>
-          </gmd:deliveryPoint>
-          <gmd:administrativeArea xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ contact['administrativearea_en']|e }}</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">{{ contact['administrativearea_fr']|e }}</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </gmd:administrativeArea>
+          {{ cs.get_freetext('deliveryPoint', 'fra', get_charstring('address', contact, 'en', 'fr')) }}
+          {{ cs.get_freetext('city', 'fra', get_charstring('city', contact, 'en', 'fr')) }}
+          {{ cs.get_freetext('administrativeArea', 'fra', get_charstring('administrativearea', contact, 'en', 'fr')) }}
           <gmd:postalCode>
             <gco:CharacterString>{{ contact['postalcode'] }}</gco:CharacterString>
           </gmd:postalCode>
-          <gmd:country>
-            <gco:CharacterString>{{ contact['country'] }}</gco:CharacterString>
-          </gmd:country>
-          <gmd:electronicMailAddress>
-            <gco:CharacterString>{{ contact['email'] }}</gco:CharacterString>
-          </gmd:electronicMailAddress>
+          {{ cs.get_freetext('country', 'fra', get_charstring('country', contact, 'en', 'fr')) }}
+          {{ cs.get_freetext('electronicMailAddress', 'fra', get_charstring('email', contact, 'en', 'fr')) }}
         </gmd:CI_Address>
       </gmd:address>
       <gmd:onlineResource>
@@ -75,12 +44,8 @@
           </gmd:protocol>
         </gmd:CI_OnlineResource>
       </gmd:onlineResource>
-      <gmd:hoursOfService>
-        <gco:CharacterString>{{ contact['hoursofservice'] }}</gco:CharacterString>
-      </gmd:hoursOfService>
-      <gmd:contactInstructions>
-        <gco:CharacterString>{{ contact['contactinstructions'] }}</gco:CharacterString>
-      </gmd:contactInstructions>
+      {{ cs.get_freetext('hoursOfService', 'fra', get_charstring('hoursofservice', contact, 'en', 'fr')) }}
+      {{ cs.get_freetext('contactInstructions', 'fra', get_charstring('contactinstructions', contact, 'en', 'fr')) }}
     </gmd:CI_Contact>
   </gmd:contactInfo>
   <gmd:role>

--- a/pygeometa/templates/iso19139-hnap/main.j2
+++ b/pygeometa/templates/iso19139-hnap/main.j2
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+{% import 'common/iso19139-charstring.j2' as cs %}
 <gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd">
   <gmd:fileIdentifier>
     <gco:CharacterString>{{ record['metadata']['identifier'] }}</gco:CharacterString>
@@ -137,14 +138,7 @@
     <gmd:MD_DataIdentification>
       <gmd:citation>
         <gmd:CI_Citation>
-          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ record['identification']['title_en']|e }}</gco:CharacterString>
-              <gmd:PT_FreeText>
-                <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['title_fr']|e }}</gmd:LocalisedCharacterString>
-                </gmd:textGroup>
-              </gmd:PT_FreeText>
-          </gmd:title>
+          {{ cs.get_freetext('title', 'fra', get_charstring('title', record['identification'], 'en', 'fr')) }}
           {% for date_type in ['creation', 'publication', 'revision'] %}
           {% set date_parameter = '%s_date' % date_type %}
           {% if record['identification'][date_parameter] %}
@@ -169,14 +163,7 @@
           </gmd:citedResponsibleParty>
         </gmd:CI_Citation>
       </gmd:citation>
-      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
-        <gco:CharacterString>{{ record['identification']['abstract_en']|e }}</gco:CharacterString>
-          <gmd:PT_FreeText>
-            <gmd:textGroup>
-              <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['abstract_fr']|e }}</gmd:LocalisedCharacterString>
-            </gmd:textGroup>
-          </gmd:PT_FreeText>
-      </gmd:abstract>
+      {{ cs.get_freetext('abstract', 'fra', get_charstring('abstract', record['identification'], 'en', 'fr')) }}
       <gmd:status>
         <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['status'] }}">{{ record['identification']['status'] }}</gmd:MD_ProgressCode>
       </gmd:status>
@@ -190,16 +177,10 @@
       {% if record['identification']['keywords_en'] and record['identification']['keywords_fr']%}
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
-        {% for kw_en, kw_fr in zip(record['identification']['keywords_en'].split(','), record['identification']['keywords_fr'].split(',')) %}
-          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ kw_en|trim|e }}</gco:CharacterString>
-              <gmd:PT_FreeText>
-                <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#fra">{{ kw_fr|trim|e }}</gmd:LocalisedCharacterString>
-                </gmd:textGroup>
-              </gmd:PT_FreeText>
-          </gmd:keyword>
-        {% endfor %}
+          {% set keywords = get_charstring('keywords', record['identification'], 'en', 'fr') %}
+          {% for kw1, kw2 in zip(keywords[0].split(','), keywords[1].split(',')) %}
+          {{ cs.get_freetext('keyword', 'fra', [kw1, kw2]) }}
+          {% endfor %}
           <gmd:type>
             <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['keywords_type'] }}">{{ record['identification']['keywords_type'] }}</gmd:MD_KeywordTypeCode>
           </gmd:type>
@@ -208,16 +189,10 @@
       {% endif %}
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
-        {% for kw_en, kw_fr in zip(record['identification']['keywords_gc_cst_en'].split(','), record['identification']['keywords_gc_cst_fr'].split(',')) %}
-          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ kw_en|trim|e }}</gco:CharacterString>
-              <gmd:PT_FreeText>
-                <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#fra">{{ kw_fr|trim|e }}</gmd:LocalisedCharacterString>
-                </gmd:textGroup>
-              </gmd:PT_FreeText>
-          </gmd:keyword>
-        {% endfor %}
+          {% set keywords = get_charstring('keywords_gc_cst', record['identification'], 'en', 'fr') %}
+          {% for kw1, kw2 in zip(keywords[0].split(','), keywords[1].split(',')) %}
+          {{ cs.get_freetext('keyword', 'fra', [kw1, kw2]) }}
+          {% endfor %}
           <gmd:type>
             <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['keywords_type'] }}">{{ record['identification']['keywords_type'] }}</gmd:MD_KeywordTypeCode>
           </gmd:type>
@@ -262,14 +237,7 @@
       </gmd:descriptiveKeywords>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
-          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ record['identification']['hnap_category_information_en'] }}</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['hnap_category_information_fr'] }}</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </gmd:keyword>
+          {{ cs.get_freetext('keyword', 'fra', get_charstring('hnap_category_information', record['identification'], 'en', 'fr')) }}
           <gmd:type>
             <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="theme"/>
           </gmd:type>
@@ -294,14 +262,7 @@
       </gmd:descriptiveKeywords>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
-          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ record['identification']['hnap_category_geography_en'] }}</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['hnap_category_geography_fr'] }}</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </gmd:keyword>
+          {{ cs.get_freetext('keyword', 'fra', get_charstring('hnap_category_geography', record['identification'], 'en', 'fr')) }}
           <gmd:type>
             <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="place"/>
           </gmd:type>
@@ -326,14 +287,7 @@
       </gmd:descriptiveKeywords>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
-          <gmd:keyword>
-            <gco:CharacterString>{{ record['identification']['hnap_category_content_en'] }}</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['hnap_category_content_fr'] }}</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </gmd:keyword>
+          {{ cs.get_freetext('keyword', 'fra', get_charstring('hnap_category_content', record['identification'], 'en', 'fr')) }}
           <gmd:type>
             <gmd:MD_KeywordTypeCode codeList="http://nap.geogratis.gc.ca/metadata/register/napMetadataRegister.xml#IC_101" codeListValue="theme"/>
           </gmd:type>
@@ -358,14 +312,10 @@
       </gmd:descriptiveKeywords>
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
-          <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ record['identification']['rights_en']|normalize_datestring('year') }}</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['rights_fr']|normalize_datestring('year')|e }}</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </gmd:useLimitation>
+          {% set uselim = get_charstring('rights', record['identification'], 'en', 'fr') %}
+          {% set uselim_en = normalize_datestring(uselim[0], 'year') %}
+          {% set uselim_fr = normalize_datestring(uselim[1], 'year') %}
+          {{ cs.get_freetext('useLimitation', 'fra', [uselim_en, uselim_fr]) }}
           <gmd:accessConstraints>
             <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['accessconstraints'] }}">{{ record['identification']['accessconstraints'] }}</gmd:MD_RestrictionCode>
           </gmd:accessConstraints>
@@ -439,18 +389,7 @@
         </gmd:EX_Extent>
       </gmd:extent>
       {% if record['identification']['url'] %}
-      <gmd:supplementalInformation>
-        <gco:CharacterString>{{ record['identification']['url'] }}</gco:CharacterString>
-      </gmd:supplementalInformation>
-      {% elif record['identification']['url_en'] %}
-      <gmd:supplementalInformation xsi:type="gmd:PT_FreeText_PropertyType">
-        <gco:CharacterString>{{ record['identification']['url_en'] }}</gco:CharacterString>
-        <gmd:PT_FreeText>
-          <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#fra">{{ record['identification']['url_fr'] }}</gmd:LocalisedCharacterString>
-          </gmd:textGroup>
-        </gmd:PT_FreeText>
-      </gmd:supplementalInformation>
+      {{ cs.get_freetext('supplementalInformation', 'fra', get_charstring('url', record['identification'], 'en', 'fr')) }}
       {% endif %}
     </gmd:MD_DataIdentification>
   </gmd:identificationInfo>
@@ -460,14 +399,7 @@
       {% if k.startswith('distribution:') and v['format_en'] and v['format_fr'] and v['format_version'] %}
       <gmd:distributionFormat>
         <gmd:MD_Format>
-          <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ v['format_en'] }}</gco:CharacterString>
-            <gmd:PT_FreeText>
-              <gmd:textGroup>
-                <gmd:LocalisedCharacterString locale="#fra">{{ v['format_fr'] }}</gmd:LocalisedCharacterString>
-              </gmd:textGroup>
-            </gmd:PT_FreeText>
-          </gmd:name>
+          {{ cs.get_freetext('name', 'fra', get_charstring('format', v, 'en', 'fr')) }}
           <gmd:version>
             <gco:CharacterString>{{ v['format_version'] }}</gco:CharacterString>
           </gmd:version>
@@ -500,14 +432,7 @@
               <gmd:protocol>
                 <gco:CharacterString>{{ v['type'] }}</gco:CharacterString>
               </gmd:protocol>
-              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
-                <gco:CharacterString>{{ v['name_en'] }}</gco:CharacterString>
-                <gmd:PT_FreeText>
-                  <gmd:textGroup>
-                    <gmd:LocalisedCharacterString locale="#fra">{{ v['name_fr'] }}</gmd:LocalisedCharacterString>
-                  </gmd:textGroup>
-                </gmd:PT_FreeText>
-              </gmd:name>
+              {{ cs.get_freetext('name', 'fra', get_charstring('name', v, 'en', 'fr')) }}
               <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
                 <gco:CharacterString>{{ v['hnap_contenttype_en'] }};{{ v['format_en'] }};eng</gco:CharacterString>
                 <gmd:PT_FreeText>

--- a/pygeometa/templates/iso19139/contact.j2
+++ b/pygeometa/templates/iso19139/contact.j2
@@ -1,13 +1,7 @@
 <gmd:CI_ResponsibleParty>
-  <gmd:individualName>
-    <gco:CharacterString>{{ contact['individualname']|e }}</gco:CharacterString>
-  </gmd:individualName>
-  <gmd:organisationName>
-    <gco:CharacterString>{{ contact['organization']|e }}</gco:CharacterString>
-  </gmd:organisationName>
-  <gmd:positionName>
-    <gco:CharacterString>{{ contact['positionname']|e }}</gco:CharacterString>
-  </gmd:positionName>
+  {{ cs.get_freetext('individualName', record['metadata']['language_alternate'], get_charstring('individualname', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+  {{ cs.get_freetext('organisationName', record['metadata']['language_alternate'], get_charstring('organization', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+  {{ cs.get_freetext('positionName', record['metadata']['language_alternate'], get_charstring('positionname', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
   <gmd:contactInfo>
     <gmd:CI_Contact>
       <gmd:phone>
@@ -30,24 +24,14 @@
       </gmd:phone>
       <gmd:address>
         <gmd:CI_Address>
-          <gmd:deliveryPoint>
-            <gco:CharacterString>{{ contact['address']|e }}</gco:CharacterString>
-          </gmd:deliveryPoint>
-          <gmd:deliveryPoint>
-            <gco:CharacterString>{{ contact['city']|e }}</gco:CharacterString>
-          </gmd:deliveryPoint>
-          <gmd:administrativeArea>
-            <gco:CharacterString>{{ contact['administrativearea']|e }}</gco:CharacterString>
-          </gmd:administrativeArea>
+          {{ cs.get_freetext('deliveryPoint', record['metadata']['language_alternate'], get_charstring('address', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+          {{ cs.get_freetext('city', record['metadata']['language_alternate'], get_charstring('city', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+          {{ cs.get_freetext('administrativeArea', record['metadata']['language_alternate'], get_charstring('administrativearea', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
           <gmd:postalCode>
             <gco:CharacterString>{{ contact['postalcode'] }}</gco:CharacterString>
           </gmd:postalCode>
-          <gmd:country>
-            <gco:CharacterString>{{ contact['country'] }}</gco:CharacterString>
-          </gmd:country>
-          <gmd:electronicMailAddress>
-            <gco:CharacterString>{{ contact['email'] }}</gco:CharacterString>
-          </gmd:electronicMailAddress>
+          {{ cs.get_freetext('country', record['metadata']['language_alternate'], get_charstring('country', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+          {{ cs.get_freetext('electronicMailAddress', record['metadata']['language_alternate'], get_charstring('email', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
         </gmd:CI_Address>
       </gmd:address>
       <gmd:onlineResource>
@@ -55,14 +39,13 @@
           <gmd:linkage>
             <gmd:URL>{{ contact['url']|e }}</gmd:URL>
           </gmd:linkage>
+          <gmd:protocol>
+            <gco:CharacterString>WWW:LINK</gco:CharacterString>
+          </gmd:protocol>
         </gmd:CI_OnlineResource>
       </gmd:onlineResource>
-      <gmd:hoursOfService>
-        <gco:CharacterString>{{ contact['hoursofservice'] }}</gco:CharacterString>
-      </gmd:hoursOfService>
-      <gmd:contactInstructions>
-        <gco:CharacterString>{{ contact['contactinstructions'] }}</gco:CharacterString>
-      </gmd:contactInstructions>
+      {{ cs.get_freetext('hoursOfService', record['metadata']['language_alternate'], get_charstring('hoursofservice', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+      {{ cs.get_freetext('contactInstructions', record['metadata']['language_alternate'], get_charstring('contactinstructions', contact, record['metadata']['language'], record['metadata']['language_alternate'])) }}
     </gmd:CI_Contact>
   </gmd:contactInfo>
   <gmd:role>

--- a/pygeometa/templates/iso19139/main.j2
+++ b/pygeometa/templates/iso19139/main.j2
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+{% import 'common/iso19139-charstring.j2' as cs %}
 <gmd:MD_Metadata xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://www.isotc211.org/2005/gmd/gmd.xsd http://www.isotc211.org/2005/gmx http://www.isotc211.org/2005/gmx/gmx.xsd">
   <gmd:fileIdentifier>
     <gco:CharacterString>{{ record['metadata']['identifier'] }}</gco:CharacterString>
   </gmd:fileIdentifier>
   <gmd:language>
-    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="eng">English</gmd:LanguageCode>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="{{ record['metadata']['language'] }}">{{ record['metadata']['language'] }}</gmd:LanguageCode>
   </gmd:language>
   <gmd:characterSet>
     <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['metadata']['charset'] }}">{{ record['metadata']['charset'] }}</gmd:MD_CharacterSetCode>
@@ -39,19 +40,18 @@
   <gmd:dataSetURI>
     <gco:CharacterString>{{ record['metadata']['dataseturi'] }}</gco:CharacterString>
   </gmd:dataSetURI>
+  {% if record['metadata']['language_alternate'] %}
   <gmd:locale>
     <gmd:PT_Locale id="locale-fr">
       <gmd:languageCode>
-        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="fra">French</gmd:LanguageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeSpace="ISO 639-2" codeListValue="{{ record['metadata']['language_alternate'] }}">{{ record['metadata']['language_alternate'] }}</gmd:LanguageCode>
       </gmd:languageCode>
-      <gmd:country>
-        <gmd:Country codeList="https://www.iso.org/obp/ui/#search/code/" codeSpace="ISO 3166-1 alpha 3" codeListValue="CAN">Canada</gmd:Country>
-      </gmd:country>
       <gmd:characterEncoding>
-        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="utf8">utf8</gmd:MD_CharacterSetCode>
+        <gmd:MD_CharacterSetCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['metadata']['charset'] }}">{{ record['metadata']['charset'] }}</gmd:MD_CharacterSetCode>
       </gmd:characterEncoding>
     </gmd:PT_Locale>
   </gmd:locale>
+  {% endif %}
   <gmd:spatialRepresentationInfo>
     {% if record['spatial']['datatype'] == 'vector' %}
     <gmd:MD_VectorSpatialRepresentation>
@@ -124,14 +124,7 @@
     <gmd:MD_DataIdentification>
       <gmd:citation>
         <gmd:CI_Citation>
-          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ record['identification']['title_en']|e }}</gco:CharacterString>
-              <gmd:PT_FreeText>
-                <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#locale-fr">{{ record['identification']['title_fr']|e }}</gmd:LocalisedCharacterString>
-                </gmd:textGroup>
-              </gmd:PT_FreeText>
-          </gmd:title>
+          {{ cs.get_freetext('title', record['metadata']['language_alternate'], get_charstring('title', record['identification'], record['metadata']['language'], record['metadata']['language_alternate'])) }}
           {% for date_type in ['creation', 'publication', 'revision'] %}
           {% set date_parameter = '%s_date' % date_type %}
           {% if record['identification'][date_parameter] %}
@@ -153,14 +146,7 @@
           {% endfor %}
         </gmd:CI_Citation>
       </gmd:citation>
-      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
-        <gco:CharacterString>{{ record['identification']['abstract_en']|e }}</gco:CharacterString>
-          <gmd:PT_FreeText>
-            <gmd:textGroup>
-              <gmd:LocalisedCharacterString locale="#locale-fr">{{ record['identification']['abstract_fr']|e }}</gmd:LocalisedCharacterString>
-            </gmd:textGroup>
-          </gmd:PT_FreeText>
-      </gmd:abstract>
+      {{ cs.get_freetext('abstract', record['metadata']['language_alternate'], get_charstring('abstract', record['identification'], record['metadata']['language'], record['metadata']['language_alternate'])) }}
       <gmd:status>
         <gmd:MD_ProgressCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_ProgressCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['status'] }}">{{ record['identification']['status'] }}</gmd:MD_ProgressCode>
       </gmd:status>
@@ -173,15 +159,9 @@
       </gmd:resourceMaintenance>
       <gmd:descriptiveKeywords>
         <gmd:MD_Keywords>
-        {% for kw_en, kw_fr in zip(record['identification']['keywords_en'].split(','), record['identification']['keywords_fr'].split(',')) %}
-          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
-            <gco:CharacterString>{{ kw_en|trim|e }}</gco:CharacterString>
-              <gmd:PT_FreeText>
-                <gmd:textGroup>
-                  <gmd:LocalisedCharacterString locale="#locale-fr">{{ kw_fr|trim|e }}</gmd:LocalisedCharacterString>
-                </gmd:textGroup>
-              </gmd:PT_FreeText>
-          </gmd:keyword>
+        {% set keywords = get_charstring('keywords', record['identification'], record['metadata']['language'], record['metadata']['language_alternate']) %}
+        {% for kw1, kw2 in zip(keywords[0].split(','), keywords[1].split(',')) %}
+        {{ cs.get_freetext('keyword', record['metadata']['language_alternate'], [kw1, kw2]) }}
         {% endfor %}
           <gmd:type>
             <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_KeywordTypeCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['keywords_type'] }}">{{ record['identification']['keywords_type'] }}</gmd:MD_KeywordTypeCode>
@@ -263,18 +243,7 @@
         </gmd:EX_Extent>
       </gmd:extent>
       {% if record['identification']['url'] %}
-      <gmd:supplementalInformation>
-        <gco:CharacterString>{{ record['identification']['url'] }}</gco:CharacterString>
-      </gmd:supplementalInformation>
-      {% elif record['identification']['url_en'] %}
-      <gmd:supplementalInformation xsi:type="gmd:PT_FreeText_PropertyType">
-        <gco:CharacterString>{{ record['identification']['url_en'] }}</gco:CharacterString>
-        <gmd:PT_FreeText>
-          <gmd:textGroup>
-            <gmd:LocalisedCharacterString locale="#locale-fr">{{ record['identification']['url_fr'] }}</gmd:LocalisedCharacterString>
-          </gmd:textGroup>
-        </gmd:PT_FreeText>
-      </gmd:supplementalInformation>
+      {{ cs.get_freetext('supplementalInformation', record['metadata']['language_alternate'], get_charstring('url', record['identification'], record['metadata']['language'], record['metadata']['language_alternate'])) }}
       {% endif %}
     </gmd:MD_DataIdentification>
   </gmd:identificationInfo>
@@ -315,22 +284,8 @@
               <gmd:protocol>
                 <gco:CharacterString>{{ v['type'] }}</gco:CharacterString>
               </gmd:protocol>
-              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
-                <gco:CharacterString>{{ v['name_en'] }}</gco:CharacterString>
-                <gmd:PT_FreeText>
-                  <gmd:textGroup>
-                    <gmd:LocalisedCharacterString locale="#locale-fr">{{ v['name_fr'] }}</gmd:LocalisedCharacterString>
-                  </gmd:textGroup>
-                </gmd:PT_FreeText>
-              </gmd:name>
-              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
-                <gco:CharacterString>{{ v['description_en'] }}</gco:CharacterString>
-                <gmd:PT_FreeText>
-                  <gmd:textGroup>
-                    <gmd:LocalisedCharacterString locale="#locale-fr">{{ v['description_fr'] }}</gmd:LocalisedCharacterString>
-                  </gmd:textGroup>
-                </gmd:PT_FreeText>
-              </gmd:description>
+              {{ cs.get_freetext('name', record['metadata']['language_alternate'], get_charstring('name', v, record['metadata']['language'], record['metadata']['language_alternate'])) }}
+              {{ cs.get_freetext('description', record['metadata']['language_alternate'], get_charstring('description', v, record['metadata']['language'], record['metadata']['language_alternate'])) }}
               <gmd:function>
                 <gmd:CI_OnLineFunctionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#CI_OnLineFunctionCode" codeSpace="ISOTC211/19115" codeListValue="{{ v['function'] }}">{{ v['function'] }}</gmd:CI_OnLineFunctionCode>
               </gmd:function>

--- a/sample.mcf
+++ b/sample.mcf
@@ -1,6 +1,7 @@
 [metadata]
 identifier=3f342f64-9348-11df-ba6a-0014c2c00eab
-language=eng; CAN
+language=en
+language_alternate=fr
 charset=utf8
 parentidentifier=someparentid
 hierarchylevel=dataset
@@ -20,8 +21,8 @@ title_en=title in English
 title_fr=title in French
 abstract_en=abstract in English
 abstract_fr=abstract in French
-keywords_en=kw1,kw2,kw3
-keywords_fr=kw1,kw2,kw3
+keywords_en=kw1 in English,kw2 in English,kw3 in English
+keywords_fr=kw1 in French,kw2 in French,kw3 in French
 keywords_type=theme
 keywords_gc_cst_en=kw1,kw2
 keywords_gc_cst_fr=kw1,kw2

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -49,7 +49,7 @@ import unittest
 from six import text_type
 
 from pygeometa import (read_mcf, pretty_print,
-                       render_template, get_supported_schemas)
+                       render_template, get_charstring, get_supported_schemas)
 
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -92,10 +92,40 @@ class PygeometaTest(unittest.TestCase):
         self.assertEqual(xml2[-1], '>', 'Expected closing bracket')
         self.assertTrue(xml2.startswith('<?xml'), 'Expected XML declaration')
 
+    def test_get_charstring(self):
+        """Test support of unilingual or multilingual value(s)"""
+
+        values = get_charstring('title', {'title': 'foo'}, 'en')
+        self.assertEqual(values, ['foo', None], 'Expected specific values')
+
+        values = get_charstring('title',
+                                {'title_en': 'foo', 'title_fr': 'bar'},
+                                'en', 'fr')
+        self.assertEqual(values, ['foo', 'bar'], 'Expected specific values')
+
+        values = get_charstring('title',
+                                {'title': 'foo', 'title_fr': 'bar'},
+                                'en', 'fr')
+        self.assertEqual(values, ['foo', 'bar'], 'Expected specific values')
+
+        values = get_charstring('title',
+                                {'title_fr': 'foo', 'title_en': 'bar'},
+                                'fr', 'en')
+        self.assertEqual(values, ['foo', 'bar'], 'Expected specific values')
+
+        values = get_charstring('title',
+                                {'title_fr': 'foo', 'title_en': 'bar'}, 'fr')
+        self.assertEqual(values, ['foo', None], 'Expected specific values')
+
+        values = get_charstring('notfound',
+                                {'title_fr': 'foo', 'title_en': 'bar'}, 'fr')
+        self.assertEqual(values, [None, None], 'Expected specific values')
+
     def test_get_supported_schemas(self):
         """Test supported schemas"""
 
         schemas = sorted(get_supported_schemas())
+        schemas.remove('common')  # remove shared snippets
         self.assertIsInstance(schemas, list, 'Expected list')
         self.assertEqual(len(schemas), 2, 'Expected 2 supported schemas')
         self.assertEqual(schemas, sorted(['iso19139', 'iso19139-hnap']),


### PR DESCRIPTION
## Overview

This PR implements #33 as a means to support default and alternate languages in ISO metadata.

## Implementation
Multilingual support is driven by the following sections in `[metadata]`:

- `language`: 2 letter language code (i.e. `en`, `fr`) of primary language
- `language_alternate` (**new**): 2 letter language code (i.e. `en`, `fr`) of secondary language

Example:

```
[metadata]
language=en
language_alternate=fr
...
```

If `language_alternate` is not defined/missing, pygeometa assumes a single language.

Values which support multilingual values can be specified with `_xx` suffixes to denote the respective language.  Examples:

```
# single language
title=foo

# two languages, no default suffix
title=foo
title_fr=bar

# two languages, explicit default suffix
title_en=foo
title_fr=bar
```

## Backward Compatibility
The `metadata/language` value **must** now be a 2 letter language code.

## Tests

Unit tests have been updated to test multilingual handling.

## Documentation
Docs need to be updated to describe the new multilingual mechanism as well as backward compatibility.