### PR TITLE
Added setuptools import in preference to distutils 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,10 @@
 #
 # =================================================================
 
-from distutils.core import setup, Command
+try:
+    from setuptools import setup, Command
+except:
+    from distutils.core import setup, Command
 import os
 import sys
 


### PR DESCRIPTION
This change enables use of  the `python setup.py develop` command. `python setup.py develop` enables you to edit the code in-situ and the effects take place immediately.

As far as I can tell there don't seem to be any side effects to using setuptools in preference to distutils.

Currently when trying to use:
` python setup.py develop` you get an error: `invalid command 'develop'`

This can be avoided by using setuptools in preference to distutils.
This pull request imports setuptools but falls back to distutils if necessary.


(Note that `pip install -e .` has the same effect as `python setup.py develop` so this fix is non-critical but is a nice to have)



