### PR TITLE
get unique transfer option for wmo-cmp and iso19139

### DIFF
--- a/pygeometa/core.py
+++ b/pygeometa/core.py
@@ -172,6 +172,25 @@ def prune_distribution_formats(formats):
     return unique_formats
 
 
+def prune_transfer_option(formats, language):
+    """derive a unique list of transfer options.
+    The unique character is based on identification language"""
+
+    unique_transfer = []
+    nil_reasons = ['missing',
+                   'withheld',
+                   'inapplicable',
+                   'unknown',
+                   'template']
+
+    for k, v in formats.items():
+            if language.split(";")[0] in k and language not in nil_reasons:
+                unique_transfer.append(v)
+            elif language in nil_reasons:
+                unique_transfer.append(v)
+    return unique_transfer
+
+
 def read_mcf(mcf):
     """returns dict of YAML file from filepath, string or dict"""
 
@@ -286,10 +305,12 @@ def render_template(mcf, schema=None, schema_local=None):
     env.filters['get_distribution_language'] = get_distribution_language
     env.filters['get_charstring'] = get_charstring
     env.filters['prune_distribution_formats'] = prune_distribution_formats
+    env.filters['prune_transfer_option'] = prune_transfer_option
     env.globals.update(zip=zip)
     env.globals.update(get_charstring=get_charstring)
     env.globals.update(normalize_datestring=normalize_datestring)
     env.globals.update(prune_distribution_formats=prune_distribution_formats)
+    env.globals.update(prune_transfer_option=prune_transfer_option)
 
     try:
         LOGGER.debug('Loading template')

--- a/pygeometa/templates/iso19139/main.j2
+++ b/pygeometa/templates/iso19139/main.j2
@@ -292,7 +292,7 @@
       </gmd:distributor>
       <gmd:transferOptions>
         <gmd:MD_DigitalTransferOptions>
-        {% set formats = prune_distribution_formats(record['distribution']) %}
+        {% set formats = prune_transfer_option(record['distribution'], record['identification']['language']) %}
         {% for v in formats %}
           <gmd:onLine>
             <gmd:CI_OnlineResource>

--- a/pygeometa/templates/wmo-cmp/main.j2
+++ b/pygeometa/templates/wmo-cmp/main.j2
@@ -336,7 +336,7 @@
       </gmd:distributor>
       <gmd:transferOptions>
         <gmd:MD_DigitalTransferOptions>
-        {% set formats = prune_distribution_formats(record['distribution']) %}
+        {% set formats = prune_transfer_option(record['distribution'], record['identification']['language']) %}
         {% for v in formats %}
           <gmd:onLine>
             <gmd:CI_OnlineResource>

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -54,7 +54,8 @@ import yaml
 
 from pygeometa.core import (read_mcf, pretty_print, render_template,
                             get_charstring, get_supported_schemas,
-                            prune_distribution_formats, MCFReadError)
+                            prune_distribution_formats,
+                            prune_transfer_option, MCFReadError)
 
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -182,6 +183,27 @@ class PygeometaTest(unittest.TestCase):
 
         self.assertEqual(len(new_formats), 2,
                          'Expected 2 unique distribution formats')
+
+    def test_prune_transfer_option(self):
+        """Test deriving unique trasnfer options"""
+
+        language = "eng; CAN"
+        unique_transfer = {
+            'waf_eng-CAN': {
+                'name': 'Datamart'
+            },
+            'wms_eng-CAN': {
+                'name': 'GeoMet'
+            },
+            'wms_fra-CAN': {
+                'name': 'GeoMet french'
+            }
+        }
+
+        new_transfer = prune_transfer_option(unique_transfer, language)
+
+        self.assertEqual(len(new_transfer), 2,
+                         'Expected 2 unique transfer option')
 
     def test_get_supported_schemas(self):
         """Test supported schemas"""


### PR DESCRIPTION
added a little function to keep only one instance of transfer option. This affects only wmo-cmp and iso19139 metadata profiles.