### PR TITLE
 doc/wmo-wigos.md: columns interchanged

### DIFF
--- a/doc/wmo-wigos.md
+++ b/doc/wmo-wigos.md
@@ -34,12 +34,12 @@ with key objects having the model below.
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
 identifier|Mandatory|WMO WIGOS identifier|0-20008-0-JFJ|WIGOS Metadata Representation, Section 8.6.4
-name|WIGOS Metadata Representation, Section 4.3
-type|The type of the observing facility from the MonitoringFacilityType codelist (http://test.wmocodes.info/wmdr/_FacilityType)|Optional|landFixed|WIGOS Metadata Representation, Section 4.3.2
+name|Mandatory|WIGOS Metadata Representation, Section 4.3
+type|Optional|The type of the observing facility from the MonitoringFacilityType codelist (http://test.wmocodes.info/wmdr/_FacilityType)|landFixed|WIGOS Metadata Representation, Section 4.3.2
 geopositioning_method|Element describes the geospatial refer ence system used for the specified geolocation (codelist http://test.wmocodes.info/wmdr/_GeopositioningMethod)|Optional|gps|WIGOS Metadata Representation, Section 4.2.2
-url|An online resource containing additional information about the facility or equipment|Optional|https://example.org/station/123|WIGOS Metadata Representation, Section 4.2.2
-date_established|Date at which the observingFacility was established. Normally considered to be the date the first observations were made|Mandatory|2011-11-11T11:11:11Z|WIGOS Metadata Representation, Section 4.3.2
-wmo_region|The WMO region the observing facility is located in, from the WMORegionType codelist (http://test.wmocodes.info/wmdr/_WMORegion)|Mandatory|northCentralAmericaCaribbean|WIGOS Metadata Representation, Section 4.3.2
+url|Optional|An online resource containing additional information about the facility or equipment|https://example.org/station/123|WIGOS Metadata Representation, Section 4.2.2
+date_established|Mandatory|Date at which the observingFacility was established. Normally considered to be the date the first observations were made|2011-11-11T11:11:11Z|WIGOS Metadata Representation, Section 4.3.2
+wmo_region|Mandatory|The WMO region the observing facility is located in, from the WMORegionType codelist (http://test.wmocodes.info/wmdr/_WMORegion)|northCentralAmericaCaribbean|WIGOS Metadata Representation, Section 4.3.2
 
 #### `territory`
 

--- a/doc/wmo-wigos.md
+++ b/doc/wmo-wigos.md
@@ -36,7 +36,7 @@ Property Name|Mandatory/Optional|Description|Example|Reference
 identifier|Mandatory|WMO WIGOS identifier|0-20008-0-JFJ|WIGOS Metadata Representation, Section 8.6.4
 name|Mandatory|WIGOS Metadata Representation, Section 4.3
 type|Optional|The type of the observing facility from the MonitoringFacilityType codelist (http://test.wmocodes.info/wmdr/_FacilityType)|landFixed|WIGOS Metadata Representation, Section 4.3.2
-geopositioning_method|Element describes the geospatial refer ence system used for the specified geolocation (codelist http://test.wmocodes.info/wmdr/_GeopositioningMethod)|Optional|gps|WIGOS Metadata Representation, Section 4.2.2
+geopositioning_method|Optional|Element describes the geospatial refer ence system used for the specified geolocation (codelist http://test.wmocodes.info/wmdr/_GeopositioningMethod)|gps|WIGOS Metadata Representation, Section 4.2.2
 url|Optional|An online resource containing additional information about the facility or equipment|https://example.org/station/123|WIGOS Metadata Representation, Section 4.2.2
 date_established|Mandatory|Date at which the observingFacility was established. Normally considered to be the date the first observations were made|2011-11-11T11:11:11Z|WIGOS Metadata Representation, Section 4.3.2
 wmo_region|Mandatory|The WMO region the observing facility is located in, from the WMORegionType codelist (http://test.wmocodes.info/wmdr/_WMORegion)|northCentralAmericaCaribbean|WIGOS Metadata Representation, Section 4.3.2
@@ -47,8 +47,8 @@ The `territory` object is a child of the `facility` object
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-name|The territory the observing facility is located in, from the TerritoryType codelist (http://test.wmocodes.info/wmdr/_TerritoryName)|Mandatory|CAN|WIGOS Metadata Representation, Section 4.3.2
-valid_period|Specifies at least the begin date of the indicated territoryName. If omitted, the dateEstablished of the facility will be assumed|Optional|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 4.3.2
+name|Mandatory|The territory the observing facility is located in, from the TerritoryType codelist (http://test.wmocodes.info/wmdr/_TerritoryName)|CAN|WIGOS Metadata Representation, Section 4.3.2
+valid_period|Optional|Specifies at least the begin date of the indicated territoryName. If omitted, the dateEstablished of the facility will be assumed|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 4.3.2
 
 #### `spatiotemporal`
 
@@ -58,5 +58,5 @@ over time.  At least one child object is required.
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-timeperiod|Specifies at least the begin date accompanying the location|Mandatory|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 7.9
-location|Representative or conventional geospatial location of observing facility, the reference location. This will always be a point location, but this location can change with time. |Mandatory.  The location property includes a `crs` property (EPSG code), and `point`` property (x,y,z)|`crs: 4326, point: -75,45,400`, `end: now`|WIGOS Metadata Representation, Section 7.9
+timeperiod|Mandatory|Specifies at least the begin date accompanying the location|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 7.9
+location|Mandatory.  The location property includes a `crs` property (EPSG code), and `point`` property (x,y,z)|Representative or conventional geospatial location of observing facility, the reference location. This will always be a point location, but this location can change with time. |`crs: 4326, point: -75,45,400`, `end: now`|WIGOS Metadata Representation, Section 7.9


### PR DESCRIPTION
the columns "mandatory/optional" and "description"  are interchanged for most items in  doc/wmo-wigos.md - this should fix it. 

btw. this is my first pull request at github. yay. Please feel free to point out anything I did wrong, still figureing it out. thank you!