### PR TITLE
Wmo-wigos program_affiliation

### DIFF
--- a/doc/wmo-wigos.md
+++ b/doc/wmo-wigos.md
@@ -34,12 +34,12 @@ with key objects having the model below.
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
 identifier|Mandatory|WMO WIGOS identifier|0-20008-0-JFJ|WIGOS Metadata Representation, Section 8.6.4
-name|WIGOS Metadata Representation, Section 4.3
-type|The type of the observing facility from the MonitoringFacilityType codelist (http://test.wmocodes.info/wmdr/_FacilityType)|Optional|landFixed|WIGOS Metadata Representation, Section 4.3.2
-geopositioning_method|Element describes the geospatial refer ence system used for the specified geolocation (codelist http://test.wmocodes.info/wmdr/_GeopositioningMethod)|Optional|gps|WIGOS Metadata Representation, Section 4.2.2
-url|An online resource containing additional information about the facility or equipment|Optional|https://example.org/station/123|WIGOS Metadata Representation, Section 4.2.2
-date_established|Date at which the observingFacility was established. Normally considered to be the date the first observations were made|Mandatory|2011-11-11T11:11:11Z|WIGOS Metadata Representation, Section 4.3.2
-wmo_region|The WMO region the observing facility is located in, from the WMORegionType codelist (http://test.wmocodes.info/wmdr/_WMORegion)|Mandatory|northCentralAmericaCaribbean|WIGOS Metadata Representation, Section 4.3.2
+name|Mandatory|||WIGOS Metadata Representation, Section 4.3
+type|Optional|The type of the observing facility from the MonitoringFacilityType codelist (http://test.wmocodes.info/wmdr/_FacilityType)|landFixed|WIGOS Metadata Representation, Section 4.3.2
+geopositioning_method|Optional|Element describes the geospatial refer ence system used for the specified geolocation (codelist http://test.wmocodes.info/wmdr/_GeopositioningMethod)|gps|WIGOS Metadata Representation, Section 4.2.2
+url|Optional|An online resource containing additional information about the facility or equipment|https://example.org/station/123|WIGOS Metadata Representation, Section 4.2.2
+date_established|Mandatory|Date at which the observingFacility was established. Normally considered to be the date the first observations were made|2011-11-11T11:11:11Z|WIGOS Metadata Representation, Section 4.3.2
+wmo_region|Mandatory|The WMO region the observing facility is located in, from the WMORegionType codelist (http://test.wmocodes.info/wmdr/_WMORegion)|northCentralAmericaCaribbean|WIGOS Metadata Representation, Section 4.3.2
 
 #### `territory`
 
@@ -47,8 +47,8 @@ The `territory` object is a child of the `facility` object
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-name|The territory the observing facility is located in, from the TerritoryType codelist (http://test.wmocodes.info/wmdr/_TerritoryName)|Mandatory|CAN|WIGOS Metadata Representation, Section 4.3.2
-valid_period|Specifies at least the begin date of the indicated territoryName. If omitted, the dateEstablished of the facility will be assumed|Optional|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 4.3.2
+name|Mandatory|The territory the observing facility is located in, from the TerritoryType codelist (http://test.wmocodes.info/wmdr/_TerritoryName)|CAN|WIGOS Metadata Representation, Section 4.3.2
+valid_period|Optional|Specifies at least the begin date of the indicated territoryName. If omitted, the dateEstablished of the facility will be assumed|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 4.3.2
 
 #### `spatiotemporal`
 
@@ -58,5 +58,5 @@ over time.  At least one child object is required.
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-timeperiod|Specifies at least the begin date accompanying the location|Mandatory|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 7.9
-location|Representative or conventional geospatial location of observing facility, the reference location. This will always be a point location, but this location can change with time. |Mandatory.  The location property includes a `crs` property (EPSG code), and `point`` property (x,y,z)|`crs: 4326, point: -75,45,400`, `end: now`|WIGOS Metadata Representation, Section 7.9
+timeperiod|Mandatory|Specifies at least the begin date accompanying the location|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 7.9
+location|Mandatory.  The location property includes a `crs` property (EPSG code), and `point` property (x,y,z)|Representative or conventional geospatial location of observing facility, the reference location. This will always be a point location, but this location can change with time. |`crs: 4326, point: -75,45,400`, `end: now`|WIGOS Metadata Representation, Section 7.9

--- a/doc/wmo-wigos.md
+++ b/doc/wmo-wigos.md
@@ -73,8 +73,9 @@ program|Mandatory|Program Affiliation, see http://test.wmocodes.info/wmdr/Progra
 The `reporting_status` object is a child of the `program_affiliation` object and
 allows for specifying 1..n child objects to model program affiliations reporting status
 over time.
+
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-status|Mandatory|Declared reporting status of the observing facility from the ReportingStatusType codelist (http://test.wmocodes.info/wmdr/_ReportingStatus)|operational|
+status|Mandatory|Declared reporting status of the observing facility from the ReportingStatusType codelist (http://test.wmocodes.info/wmdr/_ReportingStatus)|oerational|
 valid_period|Optional|Specifies at least the begin date of the indicated reportingStatus.|`begin:2011-11-11`, `end: now`|
 

--- a/doc/wmo-wigos.md
+++ b/doc/wmo-wigos.md
@@ -60,3 +60,21 @@ Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
 timeperiod|Mandatory|Specifies at least the begin date accompanying the location|`begin:2011-11-11`, `end: now`|WIGOS Metadata Representation, Section 7.9
 location|Mandatory.  The location property includes a `crs` property (EPSG code), and `point` property (x,y,z)|Representative or conventional geospatial location of observing facility, the reference location. This will always be a point location, but this location can change with time. |`crs: 4326, point: -75,45,400`, `end: now`|WIGOS Metadata Representation, Section 7.9
+
+#### `program_affiliation`
+The `program_affiliation` object is a child of the `facility` object and
+allows for specifying 1..n child objects to model program affiliations.
+
+Property Name|Mandatory/Optional|Description|Example|Reference
+-------------|------------------|-----------|-------|---------:
+program|Mandatory|Program Affiliation, see http://test.wmocodes.info/wmdr/ProgramAffiliation|`GOS`|WIGOS Metadata Representation, Section 4.3.2
+
+#### `reporting_status`
+The `reporting_status` object is a child of the `program_affiliation` object and
+allows for specifying 1..n child objects to model program affiliations reporting status
+over time.
+Property Name|Mandatory/Optional|Description|Example|Reference
+-------------|------------------|-----------|-------|---------:
+status|Mandatory|Declared reporting status of the observing facility from the ReportingStatusType codelist (http://test.wmocodes.info/wmdr/_ReportingStatus)|operational|
+valid_period|Optional|Specifies at least the begin date of the indicated reportingStatus.|`begin:2011-11-11`, `end: now`|
+

--- a/pygeometa/templates/wmo-wigos/main.j2
+++ b/pygeometa/templates/wmo-wigos/main.j2
@@ -79,22 +79,28 @@
                     <wmdr:territoryName xlink:href="http://codes.wmo.int/wmdr/TerritoryName/{{ v['territory_name']|upper }}"/>
                 </wmdr:Territory>
             </wmdr:territory>
-            {% for item in v['program_affiliation'][:1] %}
+            {% for pa in v['program_affiliation'] %}
+            {% set outer_loop = loop %}
             <wmdr:programAffiliation>
                 <wmdr:ProgramAffiliation>
-                    <wmdr:programAffiliation xlink:href="http://codes.wmo.int/wmdr/ProgramAffiliation/{{ item }}"/>
+                    <wmdr:programAffiliation xlink:href="http://codes.wmo.int/wmdr/ProgramAffiliation/{{ pa['program'] }}"/>
+                    {% for rs in pa['reporting_status'] %}
                     <wmdr:reportingStatus>
                         <wmdr:ReportingStatus>
-                            <wmdr:reportingStatus xlink:href="http://codes.wmo.int/wmdr/ReportingStatus/{{ v['status'] }}"/>
+                            <wmdr:reportingStatus xlink:href="http://codes.wmo.int/wmdr/ReportingStatus/{{ rs['status'] }}"/>
+                            <wmdr:validPeriod>
+                                 <gml:TimePeriod gml:id="stp_{{ outer_loop.index }}_{{ loop.index }}">
+                                    <gml:beginPosition>{{ rs['valid_period']['begin'] }}</gml:beginPosition>
+                                    {% if rs['valid_period']['end'] %}
+                                    <gml:endPosition>{{ rs['valid_period']['end'] }}</gml:endPosition>
+                                    {% else %}
+                                    <gml:endPosition indeterminatePosition="now"/>
+                                    {% endif %}
+                                </gml:TimePeriod>
+                            </wmdr:validPeriod>
                         </wmdr:ReportingStatus>
                     </wmdr:reportingStatus>
-                </wmdr:ProgramAffiliation>
-            </wmdr:programAffiliation>
-            {% endfor %}
-            {% for item in v['program_affiliation'][1:] %}
-            <wmdr:programAffiliation>
-                <wmdr:ProgramAffiliation>
-                    <wmdr:programAffiliation xlink:href="http://codes.wmo.int/wmdr/ProgramAffiliation/{{ item }}"/>
+                    {% endfor %}
                 </wmdr:ProgramAffiliation>
             </wmdr:programAffiliation>
             {% endfor %}

--- a/sample-wmo-wigos.yml
+++ b/sample-wmo-wigos.yml
@@ -44,8 +44,23 @@ facility:
                  crs: 4326
                  point: -75,45,400
         date_established: 1999-11-11
-        program_affiliation: ['WIGOSnonAffiliated']
-        status: operational
+        program_affiliation:
+            - program: 'WIGOSnonAffiliated'
+              reporting_status:
+                - valid_period:
+                    begin: 1999-11-11
+                    end: now # optional
+                  status: operational
+            - program: 'GOS'
+              reporting_status:
+                - valid_period:
+                    begin: 1999-11-11
+                    end:  2018-08-02
+                  status: operational
+                - valid_period:
+                    begin: 2018-08-02
+                    end: now # optional
+                  status: closed
         territory:
             name: CAN
             valid_period:


### PR DESCRIPTION
The WMO WIGOS Metadata Standard Reference allows various program/network affiliations with a reporting-status that may change over time (e.g. operational, closed).
As far as I undersand it, the current template does not reflect that.
To fix this, I propose changes in the templated, and accordingly in the sample-yaml and documentation.

Also, I'm new to git and github.. please let me know if I did anything wrong and/or could do it better! Still figuring it out. Thanks!
