### PR TITLE
remove Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ addons:
       - pandoc
 
 python:
-  - "2.7"
-  - "3.4"
+  - "3.5"
 
 install:
   - pip install -r requirements-dev.txt

--- a/pygeometa/migrations.py
+++ b/pygeometa/migrations.py
@@ -47,7 +47,7 @@ import codecs
 import logging
 
 import click
-from six.moves.configparser import SafeConfigParser as ConfigParser
+from configparser import SafeConfigParser
 import yaml
 
 LOGGER = logging.getLogger(__name__)
@@ -55,7 +55,7 @@ LOGGER = logging.getLogger(__name__)
 
 def configparser2yaml(cpfile):
     dict_ = {}
-    cp = ConfigParser()
+    cp = SafeConfigParser()
 
     with codecs.open(cpfile, encoding='utf-8') as fh:
         cp.readfp(fh)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Click
 Jinja2
-six
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -84,12 +84,7 @@ def get_package_version():
     raise RuntimeError("Unable to find version string.")
 
 
-try:
-    import pypandoc
-    LONG_DESCRIPTION = pypandoc.convert('README.md', 'rst')
-except(IOError, ImportError, OSError):
-    print('Conversion to rST failed.  Using default (will look weird on PyPI)')
-    LONG_DESCRIPTION = read('README.md')
+LONG_DESCRIPTION = read('README.md')
 
 DESCRIPTION = 'pygeometa is a Python package to generate metadata for geospatial datasets'  # noqa
 
@@ -101,6 +96,7 @@ setup(
     version=get_package_version(),
     description=DESCRIPTION.strip(),
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     license='MIT',
     platforms='all',
     keywords=' '.join([

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -49,7 +49,6 @@ import datetime
 import os
 import unittest
 
-from six import text_type
 import yaml
 
 from pygeometa.core import (read_mcf, pretty_print, render_template,
@@ -132,7 +131,7 @@ class PygeometaTest(unittest.TestCase):
         xml = render_template(get_abspath('../sample.yml'), 'iso19139')
         xml2 = pretty_print(xml)
 
-        self.assertIsInstance(xml2, text_type, 'Expected unicode string')
+        self.assertIsInstance(xml2, str, 'Expected unicode string')
         self.assertEqual(xml2[-1], '>', 'Expected closing bracket')
         self.assertTrue(xml2.startswith('<?xml'), 'Expected XML declaration')
 
@@ -234,7 +233,7 @@ class PygeometaTest(unittest.TestCase):
 
         for mcf_path in test_mcf_paths:
             xml = render_template(get_abspath(mcf_path), 'iso19139')
-            self.assertIsInstance(xml, text_type, 'Expected unicode string')
+            self.assertIsInstance(xml, str, 'Expected unicode string')
 
             # no schema provided
             with self.assertRaises(RuntimeError):
@@ -294,7 +293,7 @@ class PygeometaTest(unittest.TestCase):
         """test datestrings that are pre-1900"""
 
         xml = render_template(get_abspath('dates-pre-1900.yml'), 'iso19139')
-        self.assertIsInstance(xml, text_type, 'Expected unicode string')
+        self.assertIsInstance(xml, str, 'Expected unicode string')
 
     def test_broken_yaml(self):
         """test against broken YAML"""


### PR DESCRIPTION
This PR removes Python 2.x support and bumps Travis testing to 3.5.  It's time.