### PR TITLE
OARec wcmp2 fixes

### DIFF
--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -316,8 +316,7 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
             LOGGER.debug('Formatting phone number')
             phone = contact['phone']
             phone = phone.replace('-', '').replace('(', '').replace(')', '')
-            phone = phone.replace('+0', '').replace(' ', '')
-            phone = f'+{phone}'
+            phone = phone.replace('+0', '+').replace(' ', '')
 
             rp['phones'] = [{'value': phone}]
         if contact.get('email') is not None:

--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -49,7 +49,7 @@ import logging
 import os
 from typing import Union
 
-from pygeometa.core import get_charstring, normalize_datestring
+from pygeometa.core import get_charstring
 from pygeometa.helpers import json_serial
 from pygeometa.schemas.base import BaseOutputSchema
 
@@ -157,11 +157,16 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
                 record['properties']['created'] = str(mcf['identification']['dates']['creation'])  # noqa
             if 'revision' in mcf['identification']['dates']:
                 record['properties']['updated'] = str(mcf['identification']['dates']['revision'])  # noqa
-            if 'publication' in mcf['identification']['dates']:
-                record['properties']['updated'] = normalize_datestring(mcf['identification']['dates']['publication'])  # noqa
 
         if record['properties'].get('created') is None:
                 record['properties']['created'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
+
+        for date_type in ['created', 'updated']:
+            ds = record['properties'].get(date_type)
+            if ds is not None and len(ds) == 10:
+                LOGGER.debug('Date type found; expanding to date-time')
+                dt = datetime.strptime(ds, '%Y-%m-%d').strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
+                record['properties'][date_type] = dt
 
         rights = get_charstring(mcf['identification'].get('rights'),
                                 self.lang1, self.lang2)
@@ -308,7 +313,13 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
             rp['addresses'][0]['country'] = country[0]
 
         if contact.get('phone') is not None:
-            rp['phones'] = [{'value': contact.get('phone')}]
+            LOGGER.debug('Formatting phone number')
+            phone = contact['phone']
+            phone = phone.replace('-', '').replace('(', '').replace(')', '')
+            phone = phone.replace('+0', '').replace(' ', '')
+            phone = f'+{phone}'
+
+            rp['phones'] = [{'value': phone}]
         if contact.get('email') is not None:
             rp['emails'] = [{'value': contact.get('email')}]
 

--- a/pygeometa/schemas/wmo_wcmp2/__init__.py
+++ b/pygeometa/schemas/wmo_wcmp2/__init__.py
@@ -106,7 +106,7 @@ class WMOWCMP2OutputSchema(OGCAPIRecordOutputSchema):
             except KeyError:
                 LOGGER.warning('Missing wmo:dataPolicy')
 
-        if 'dates' not in record['properties']:
+        if 'created' not in record['properties']:
             record['properties']['created'] = datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
 
         if stringify:


### PR DESCRIPTION
- OARec fixes:
  - ensure `properties.created` and `properties.updated` are date-time
  - ensure contact phone number is formatting according to the specification
- WCMP2: fix ref