### PR TITLE
Use field uselimitation to set rights property and license in othercontstraints

### DIFF
--- a/pygeometa/schemas/iso19139/main.j2
+++ b/pygeometa/schemas/iso19139/main.j2
@@ -239,9 +239,17 @@
       {% endfor %}
       <gmd:resourceConstraints>
         <gmd:MD_LegalConstraints>
+          {{ cs.get_freetext('useLimitation', record.get('metadata',{}).get('language_alternate'), get_charstring(record['identification'].get('rights'), record.get('metadata',{}).get('language'), record.get('metadata',{}).get('language_alternate'))) }}           
           <gmd:accessConstraints>
             <gmd:MD_RestrictionCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeSpace="ISOTC211/19115" codeListValue="{{ record['identification']['accessconstraints'] }}">{{ record['identification']['accessconstraints'] }}</gmd:MD_RestrictionCode>
           </gmd:accessConstraints>
+          {% if record['identification'].get('license',{}).get('url','').startswith('http') %}
+          <gmd:otherConstraints>
+            <gmx:Anchor xlink:href="{{ record['identification'].get('license',{}).get('url') }}">{{ record['identification'].get('license',{}).get('name') }}</gmx:Anchor>
+          </gmd:otherConstraints>
+          {% else %}
+            {{ cs.get_freetext('otherConstraints', record.get('metadata',{}).get('language_alternate'), get_charstring(record['identification'].get('license',{}).get('name',''), record.get('metadata',{}).get('language'), record.get('metadata',{}).get('language_alternate'))) }}
+          {% endif %}
         </gmd:MD_LegalConstraints>
       </gmd:resourceConstraints>
       <gmd:spatialRepresentationType>


### PR DESCRIPTION
iin iso19139:2007 export, use uselimitation as rights

see [pycsw#1077](https://github.com/geopython/pycsw/issues/1077) 

if url is provided, use gmx:anchor, else charstring