### PR TITLE
WIP: Validate non mcf schemas

### DIFF
--- a/pygeometa/schemas/__init__.py
+++ b/pygeometa/schemas/__init__.py
@@ -75,19 +75,6 @@ def get_supported_schemas(details: bool = False,
 
     :returns: list of supported schemas
     """
-
-    def has_mode(plugin: BaseOutputSchema, mode: str) -> bool:
-        enabled = False
-
-        try:
-            _ = getattr(plugin, mode)('test')
-        except NotImplementedError:
-            pass
-        except Exception:
-            enabled = True
-
-        return enabled
-
     schema_matrix = []
 
     LOGGER.debug('Generating list of supported schemas')
@@ -102,14 +89,16 @@ def get_supported_schemas(details: bool = False,
 
     for key in SCHEMAS.keys():
         schema = load_schema(key)
-        can_read = has_mode(schema, 'import_')
-        can_write = has_mode(schema, 'write')
+        can_read = schema.has_mode('import_')
+        can_write = schema.has_mode('write')
+        can_validate = schema.has_mode('validate')
 
         schema_matrix.append({
             'id': key,
             'description': schema.description,
             'read': can_read,
-            'write': can_write
+            'write': can_write,
+            'validate': can_validate
         })
 
     if include_autodetect:

--- a/pygeometa/schemas/base.py
+++ b/pygeometa/schemas/base.py
@@ -98,5 +98,25 @@ class BaseOutputSchema:
 
         raise NotImplementedError()
 
+    def validate(self, metadata: Union[dict, str]) -> bool:
+        """
+        Validate metadata against schema
+
+        :param metadata: metadata content
+
+        :returns: `bool` of validation result
+        """
+
+        raise NotImplementedError()
+
+    def has_mode(self, mode: str) -> bool:
+        """
+        Check if schema implementation supports a mode
+
+        :param mode: mode to check, e.g. 'import_', 'write', 'validate'
+        :returns: `bool` indicating whether mode is supported
+        """
+        return mode in self.__class__.__dict__
+
     def __repr__(self):
         return f'<{self.name.upper()}OutputSchema> {self.name}'

--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -167,7 +167,7 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
                 record['time']['resolution'] =  mcf['identification']['extents']['temporal'][0]['resolution']  # noqa
 
         except (IndexError, KeyError):
-            record['time'] = None
+            pass
 
         LOGGER.debug('Checking for dates')
 

--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -42,11 +42,17 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
-
+import json
 from datetime import date, datetime
 import logging
 import os
 from typing import Union
+
+import requests
+import yaml
+from jsonschema import validate as jsonschema_validate
+from jsonschema import RefResolver
+from jsonschema.exceptions import ValidationError
 
 from pygeometa import __version__
 from pygeometa.core import get_charstring
@@ -470,3 +476,45 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
             raise RuntimeError(msg)
 
         return value
+
+    def validate(self, metadata: Union[dict, str]) -> bool:
+        """
+        Validate metadata against schema
+
+        :param metadata: OGC Records metadata content
+
+        :returns: `bool` of validation result
+        """
+
+        if isinstance(metadata, str):
+            try:
+                metadata = json.loads(metadata)
+            except TypeError:
+                return False
+
+        schema_uri = 'https://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas/recordGeoJSON.yaml' # noqa
+
+        def yaml_loader(uri: str) -> dict:
+            r = requests.get(uri)
+            r.raise_for_status()
+            return yaml.safe_load(r.text)
+
+        schema_dict = yaml_loader(schema_uri)
+
+        resolver = RefResolver(
+            base_uri=schema_uri,
+            referrer=schema_dict,
+            handlers={'http': yaml_loader, 'https': yaml_loader}
+        )
+
+        try:
+            jsonschema_validate(
+                instance=metadata,
+                schema=schema_dict,
+                resolver=resolver
+            )
+        except ValidationError as err:
+            LOGGER.error(f'Validation error: {err.message}')
+            return False
+
+        return True


### PR DESCRIPTION
Adds support for validation when transforming or generating metadata for schemas other than MCF.

Opening as a WIP because I've found errors while validating the `sample.yml`, possibly bubbling out bugs in both pygeometa and OGC API Records schema. Also the validation logic written for ogcapi_records seems generalizable for more schemas.

Closes https://github.com/geopython/pygeometa/issues/264