### PR TITLE
Fix test coverage in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,11 +22,9 @@ jobs:
         pip3 install -r requirements-dev.txt
     - name: Install package 📦
       run: python3 setup.py install
-    - name: run tests ⚙️
-      run: python3 setup.py test
-    - name: run test coverage ⚙️
+    - name: run tests with coverage ⚙️
       run: |
-        coverage run --source pygeometa setup.py test
+        coverage run --source pygeometa tests/run_tests.py
         coverage report -m
     - name: build docs 🏗️
       run: mkdocs build -f docs/mkdocs.yml


### PR DESCRIPTION
I've found this while working on https://github.com/geopython/pygeometa/issues/264

The current workflow was running the tests twice, but none with coverage. When the tests are ran with

`coverage run --source pygeometa setup.py test`

coverage will not collect the data and all coverage will be shown as 0%