### PR TITLE
add `additional_identifiers` property

### DIFF
--- a/docs/content/reference/mcf.md
+++ b/docs/content/reference/mcf.md
@@ -126,6 +126,7 @@ version|Mandatory|version of MCF format|1.0|pygeometa
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
 identifier|Mandatory|unique identifier for this metadata file|11800c2c-e6b9-11df-b9ae-0014c2c00eab|ISO 19115:2003 Section B.2.1
+additional_identifiers|Optional|any additional identifiers for the resource with their scheme property|10.5324/3f342f64|ISO 19115:2003 Section B.2.1
 language|Mandatory|primary language used for documenting metadata, the metadata records themselves can be provided in multiple languages nonetheless|en|ISO 19115:2003 Section B.2.1
 language_alternate|Optional|alternate language used for documenting metadata|en|ISO 19115:2003 Annex J
 charset|Mandatory|full name of the character coding standard used for the metadata set|utf8|ISO 19115:2003 Section B.2.1

--- a/pygeometa/schemas/mcf/core.yaml
+++ b/pygeometa/schemas/mcf/core.yaml
@@ -22,6 +22,11 @@ properties:
             identifier:
                 type: string
                 description: unique identifier for this metadata file
+            additional_identifiers:
+                type: array
+                description: additional resource identifiers
+                items:
+                    $ref: '#/definitions/identifier_scheme'
             language:
                 type: string
                 description: primary language used for documenting metadata, the metadata records themselves can be provided in multiple languages nonetheless
@@ -711,3 +716,14 @@ definitions:
               format: date
             - type: string
               format: date-time
+    identifier_scheme:
+        type: object
+        properties:
+            identifier:
+                type: string
+                description: identifier
+            scheme:
+                type: string
+                description: the scheme in which this identifier is defined (e.g. ark, doi, handle, isbn, lccn, sku).  Note that the schema may also be a URI.
+        required:
+            - identifier

--- a/sample.yml
+++ b/sample.yml
@@ -3,6 +3,9 @@ mcf:
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab
+    additional_identifiers:
+        - identifier: 10.277/3f342f64-9348
+          scheme: https://doi.org/
     language: en
     language_alternate: fr
     charset: utf8


### PR DESCRIPTION
this PR suggests to add a property additional_identifiers, similar to the [externalIDS property](https://docs.ogc.org/is/20-004r1/20-004r1.html#core-properties-resource-table) in ogcapi:records

iso191115 and schema.org capture any additional identifiers (with their scheme) in an identifier-array

next PR will introduce the capability to read from and write to various profiles (schema.org, iso19115, ogcapi-records)