### PR TITLE
remove duplication in attributes

### DIFF
--- a/pygeometa/schemas/mcf/core.yaml
+++ b/pygeometa/schemas/mcf/core.yaml
@@ -356,6 +356,8 @@ properties:
                                 - object
                                 - array
                                 - boolean
+                                - date
+                                - datetime
                         units:
                             type: string
                             description: SI Unit
@@ -595,79 +597,6 @@ properties:
         required:
             - platforms
 
-    attributes:
-        type: array
-        minItems: 1
-        items:
-            type: object
-            properties:
-                name:
-                    type: string
-                    description: attribute name
-                type:
-                    type: string
-                    description: data type of attribute
-                    enum:
-                        - string
-                        - number
-                        - integer
-                        - object
-                        - array
-                        - boolean
-                units:
-                    type: string
-                    description: SI Unit
-                title:
-                    $ref: '#/definitions/i18n_string'
-                    description: human readable title of attribute
-                abstract:
-                    $ref: '#/definitions/i18n_string'
-                    description: description of attribute
-                url:
-                    $ref: '#/definitions/i18n_string'
-                    description: URL with more information about the attribute
-                values:
-                    type: object
-                    oneOf:
-                        - properties:
-                              enum:
-                                  type: array
-                                  description: enumerated list of values
-                                  minItems: 1
-                                  items:
-                                      $ref: '#/definitions/any_type'
-                        - properties:
-                              range:
-                                  type: array
-                                  description: range of values (min/max)
-                                  minItems: 2
-                                  maxItems: 2
-                                  items:
-                                      $ref: '#/definitions/any_type'
-                        - properties:
-                              codelist:
-                                  type: array
-                                  description: values from a codelist
-                                  minItems: 1
-                                  items:
-                                      type: object
-                                      properties:
-                                          name:
-                                              type: string
-                                              description: value name
-                                          title:
-                                              $ref: '#/definitions/i18n_string'
-                                              description: human readable title of value
-                                          abstract:
-                                              $ref: '#/definitions/i18n_string'
-                                              description: description of value
-                                          url:
-                                              $ref: '#/definitions/i18n_string'
-                                              description: URL with more information about the value
-                                      required:
-                                              - name
-            required:
-                - name
 
 required:
     - mcf

--- a/sample.yml
+++ b/sample.yml
@@ -73,10 +73,19 @@ content_info:
     cloud_cover: 72
     processing_level: "1.0"
     attributes:
-        - name: foo
-          units: m
-        - name: bar
-          units: K
+        - name: TS_OBS
+          title: Observation timestamp
+          type: datetime
+        - name: CA_MG_L
+          title: Calcium content in MG per L
+          type: number
+          url: https://en.wikipedia.org/wiki/Calcium
+          units: MilliGM-PER-L
+        - name: MG_MG_L
+          title: Magnesium content in MG per L
+          type: number
+          url: https://en.wikipedia.org/wiki/Magnesium
+          units: MilliGM-PER-L
     dimensions:
         - name: B1
           units: nm
@@ -139,9 +148,3 @@ dataquality:
         level: dataset
     lineage:
         statement: this dataset was derived from a custom process against dataset xyz
-
-attributes:
-    - name: foo
-      units: m
-    - name: bar
-      units: K


### PR DESCRIPTION
mcf had some duplication in the attributes section, maybe it was kept at its old location for backwards compatibility?
suggestion to clean up the second instance
 
also a suggestion to extend sample with more relevant content
extend the field types with date and datetime