### PR TITLE
add functionality to load plugins dynamically

### DIFF
--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -47,7 +47,7 @@ import logging
 import os
 from typing import Union
 
-from pygeometa import __version__
+
 from pygeometa.core import get_charstring
 from pygeometa.helpers import generate_datetime, json_dumps
 from pygeometa.schemas.base import BaseOutputSchema
@@ -247,7 +247,8 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
         for value in mcf['distribution'].values():
             record['links'].append(self.generate_link(value))
 
-        record['generated_by'] = f'pygeometa {__version__}'
+        from importlib.metadata import version
+        record['generated_by'] = f'pygeometa {version("pygeometa")}'
 
         if stringify:
             return json_dumps(record)

--- a/pygeometa/schemas/wmo_wcmp2/__init__.py
+++ b/pygeometa/schemas/wmo_wcmp2/__init__.py
@@ -71,6 +71,7 @@ class WMOWCMP2OutputSchema(OGCAPIRecordOutputSchema):
         super().__init__()
 
         self.description = description
+        self.name = 'wmo-wcmp2'
 
     def write(self, mcf: dict, stringify: str = True) -> Union[dict, str]:
         """

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -482,7 +482,7 @@ class PygeometaTest(unittest.TestCase):
         """test metadata transform"""
 
         with open(get_abspath('md-SMJP01RJTD-gmd.xml')) as fh:
-            m = transform_metadata('iso19139', 'oarec-record', fh.read())
+            m = transform_metadata('autodetect', 'oarec-record', fh.read())
 
             m = json.loads(m)
             self.assertEqual(


### PR DESCRIPTION
Loading plugins dynamically allows to copy in a plugin at runtime, without updating /schemas/__init__.py

I had to change getting the `__version__` in ogcapi-records because it caused a circular reference

I'm curious to hear if this approach is interesting?