### PR TITLE
replace identification.doi with metadata.additional_identifiers

### DIFF
--- a/docs/content/reference/mcf.md
+++ b/docs/content/reference/mcf.md
@@ -126,7 +126,6 @@ version|Mandatory|version of MCF format|1.0|pygeometa
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
 identifier|Mandatory|unique identifier for this metadata file|11800c2c-e6b9-11df-b9ae-0014c2c00eab|ISO 19115:2003 Section B.2.1
-additional_identifiers|Optional|any additional identifiers for the resource with their scheme property|10.5324/3f342f64|ISO 19115:2003 Section B.2.1
 language|Mandatory|primary language used for documenting metadata, the metadata records themselves can be provided in multiple languages nonetheless|en|ISO 19115:2003 Section B.2.1
 language_alternate|Optional|alternate language used for documenting metadata|en|ISO 19115:2003 Annex J
 charset|Mandatory|full name of the character coding standard used for the metadata set|utf8|ISO 19115:2003 Section B.2.1
@@ -134,6 +133,13 @@ parentidentifier|Optional|file identifier of the metadata to which this metadata
 hierarchylevel|Mandatory|level to which the metadata applies (must be one of 'series', 'software', 'featureType', 'model', 'collectionHardware', 'collectionSession', 'nonGeographicDataset', 'propertyType', 'fieldSession', 'dataset', 'service', 'attribute', 'attributeType', 'tile', 'feature', 'dimensionGroup'|dataset|ISO 19115:2003 Section B.2.1
 datestamp|Mandatory|date that the metadata was created, pygeometa supports specifying the $date$ or $datetime$ variable to update the date value at run time|2000-11-11 or 2000-01-12T11:11:11Z|ISO 19115:2003 Section B.2.1
 dataseturi|Optional|Uniformed Resource Identifier (URI) of the dataset to which the metadata applies|`urn:x-wmo:md:int.wmo.wis::http://geo.woudc.org/def/data/uv-radiation/uv-irradiance`|ISO 19115:2003 Section B.2.1
+
+### `metadata.additional_identifiers`
+
+Property Name|Mandatory/Optional|Description|Example|Reference
+-------------|------------------|-----------|-------|---------:
+identifier|Mandatory|identifier|10.5324/3f342f64|ISO 19115:2003 Section B.2.1
+scheme|Optional|scheme in which this identifier is defined (e.g. ark, doi, handle, isbn, lccn, sku).  Note that the schema may also be a URI|https://doi.org|ISO 19115:2003 Section B.2.1
 
 ### `spatial`
 
@@ -146,7 +152,6 @@ geomtype|Mandatory|name of point or vector objects used to locate zero-, one-, t
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-doi|Optional|Digital Object Identifier (DOI)|12345|ISO 19115:2003 Section B.3.2.1
 language|Optional|language(s) used within the dataset. If the dataset is made of numerical values, the dataset language can be set to 'missing', 'withheld', 'inapplicable', 'unknown' or 'template'|eng; CAN|ISO 19115:2003 Section B.2.2.1
 charset|Optional|full name of the character coding standard used for the dataset|eng; CAN|ISO 19115:2003 Section B.2.1
 title|Mandatory|name by which the cited resource is known|Important Bird Areas|ISO 19115:2003 Section B.3.2.1

--- a/pygeometa/schemas/mcf/core.yaml
+++ b/pygeometa/schemas/mcf/core.yaml
@@ -100,9 +100,6 @@ properties:
     identification:
         type: object
         properties:
-            doi:
-                type: string
-                description: Digital Object Identifier (DOI)
             language:
                 type: string
                 description: |-
@@ -653,6 +650,6 @@ definitions:
                 description: identifier
             scheme:
                 type: string
-                description: the scheme in which this identifier is defined (e.g. ark, doi, handle, isbn, lccn, sku).  Note that the schema may also be a URI.
+                description: scheme in which this identifier is defined (e.g. ark, doi, handle, isbn, lccn, sku).  Note that the schema may also be a URI
         required:
             - identifier

--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -121,11 +121,19 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
             'links': []
         }
 
-        if 'doi' in mcf['identification']:
-            record['properties']['externalIds'] = [{
-                'scheme': 'https://doi.org',
-                'value': mcf['identification']['doi']
-            }]
+        if 'additional_identifiers' in mcf['metadata']:
+            LOGGER.debug('Adding additional identifiers')
+
+            record['properties']['externalIds'] = []
+
+            for ai in mcf['metadata'].get('additional_identifiers', []):
+                ai_dict = {
+                    'value': ai['identifier']
+                }
+                if 'scheme' in ai:
+                    ai_dict['scheme'] = ai['scheme']
+
+                record['properties']['externalIds'].append(ai_dict)
 
         if self.lang1 is not None:
             record['properties']['language'] = {

--- a/pygeometa/schemas/wmo_cmp/main.j2
+++ b/pygeometa/schemas/wmo_cmp/main.j2
@@ -149,13 +149,15 @@
           {% if record['identification']['edition'] %}
           {{ cs.get_freetext('edition', record['metadata']['language_alternate'], get_charstring(record['identification'].get('edition'), record['metadata']['language'], record['metadata']['language_alternate'])) }}
           {% endif %}
+          {% for ai in record['metadata'].get('additional_identifiers', []) %}
           <gmd:identifier>
             <gmd:MD_Identifier>
               <gmd:code>
-                <gmx:Anchor xlink:href="http://dx.doi.org/{{ record['identification']['doi'] }}" xlink:title="DOI" xlink:actuate="onRequest">doi:{{ record['identification']['doi'] }}</gmx:Anchor>
+                <gmx:Anchor xlink:href="{{ ai['scheme'] }}/{{ ai['identifier'] }}" xlink:title="{{ai['scheme']}}" xlink:actuate="onRequest">{{ai['scheme']}}:{{ ai['identifier'] }}</gmx:Anchor>
               </gmd:code>
             </gmd:MD_Identifier>
           </gmd:identifier>
+          {% endfor %}
           {{ cs.get_freetext('otherCitationDetails', record['metadata']['language_alternate'], get_charstring(record['identification'].get('rights'), record['metadata']['language'], record['metadata']['language_alternate'])) }}
         </gmd:CI_Citation>
       </gmd:citation>

--- a/sample.yml
+++ b/sample.yml
@@ -5,7 +5,7 @@ metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab
     additional_identifiers:
         - identifier: 10.277/3f342f64-9348
-          scheme: https://doi.org/
+          scheme: https://doi.org
     language: en
     language_alternate: fr
     charset: utf8


### PR DESCRIPTION
As a follow up to #291, use `metadata.additional_identifiers` to emit DOIs