### PR TITLE
make MCF identification.extents.spatial.bbox nullable

### DIFF
--- a/docs/content/reference/mcf.md
+++ b/docs/content/reference/mcf.md
@@ -205,7 +205,7 @@ identification:
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-spatial.bbox|Mandatory|geographic position of the dataset, formatted as as list of [minx,miny,maxx,maxy]|-141,42,-52,84|ISO 19115:2003 Section B.3.1.2
+spatial.bbox|Mandatory|geographic position of the dataset, formatted as as list of [minx,miny,maxx,maxy] or null|-141,42,-52,84|ISO 19115:2003 Section B.3.1.2
 spatial.crs|Mandatory|EPSG code identifier|4326|ISO 19115:2003 Section B.2.7.3
 spatial.description|Optional|description of the geographic area using an identifier|Toronto, Ontario, Canada|ISO 19115:2003 Section B.3.1.2
 temporal.begin|Optional|Starting time period covered by the content of the dataset, either time period (startdate/enddate) or a single point in time value|1950-07-31|ISO 19115:2003 Section B.3.1.3

--- a/pygeometa/schemas/mcf/core.yaml
+++ b/pygeometa/schemas/mcf/core.yaml
@@ -274,23 +274,29 @@ properties:
                     spatial:
                         type: array
                         description: spatial extent and CRS
-                        properties:
-                            bbox:
-                                type: array
-                                description: bounding box of resource
-                                items:
-                                    type: number
-                                minItems: 4
-                                maxItems: 6
-                            crs:
-                                type: string
-                                description: coordinate reference system of bbox
-                                default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
-                            description:
-                                type: string
-                                description: description of the geographic area using an identifier
-                        required:
-                            - bbox
+                        items:
+                            type: object
+                            properties:
+                                bbox:
+                                    type:
+                                        - array
+                                        - 'null'
+                                    description: bounding box of resource
+                                    items:
+                                        type: number
+                                    minItems: 4
+                                    maxItems: 6
+                                crs:
+                                    type:
+                                        - string
+                                        - integer
+                                    description: coordinate reference system of bbox
+                                    default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+                                description:
+                                    type: string
+                                    description: description of the geographic area using an identifier
+                            required:
+                                - bbox
                     temporal:
                         type: array
                         description: temporal extent of resource

--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -86,8 +86,21 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
         self.lang1 = mcf['metadata'].get('language')
         self.lang2 = mcf['metadata'].get('language_alternate')
 
-        minx, miny, maxx, maxy = (mcf['identification']['extents']
-                                  ['spatial'][0]['bbox'])
+        try:
+            minx, miny, maxx, maxy = (mcf['identification']['extents']
+                                      ['spatial'][0]['bbox'])
+            geometry = {
+                'type': 'Polygon',
+                'coordinates': [[
+                    [minx, miny],
+                    [minx, maxy],
+                    [maxx, maxy],
+                    [maxx, miny],
+                    [minx, miny]
+                ]]
+            }
+        except TypeError:
+            geometry = None
 
         title = get_charstring(mcf['identification'].get('title'),
                                self.lang1, self.lang2)
@@ -102,16 +115,7 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
                 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-core',  # noqa
             ],
             'type': 'Feature',
-            'geometry': {
-                'type': 'Polygon',
-                'coordinates': [[
-                    [minx, miny],
-                    [minx, maxy],
-                    [maxx, maxy],
-                    [maxx, miny],
-                    [minx, miny]
-                ]]
-            },
+            'geometry': geometry,
             'properties': {
                 'title': title[0],
                 'description': description[0],


### PR DESCRIPTION
This PR updates the MCF schema to accept `null` as a supported data type (following discussion in #323).

cc @nicokant 