### PR TITLE
harden the iso19139 export, in case spatial.datatype does not exist

### DIFF
--- a/pygeometa/schemas/iso19139/main.j2
+++ b/pygeometa/schemas/iso19139/main.j2
@@ -28,7 +28,7 @@
   {% endif %}
   {% endfor %}
   <gmd:dateStamp>
-    {% set datestamp = record['metadata']['datestamp']|normalize_datestring %}
+    {% set datestamp = record['metadata'].get('datestamp','')|normalize_datestring %}
     {% if datestamp|length > 11 %}
     <gco:DateTime>{{ datestamp }}</gco:DateTime>
     {% else %}
@@ -41,9 +41,11 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>ISO 19115:2003</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  {% if record['metadata'].get('dataseturi') %}
   <gmd:dataSetURI>
     <gco:CharacterString>{{ record['metadata']['dataseturi']|e }}</gco:CharacterString>
   </gmd:dataSetURI>
+  {% endif %}
   {% if record['metadata']['language_alternate'] %}
   <gmd:locale>
     <gmd:PT_Locale id="locale-fr">
@@ -57,7 +59,7 @@
   </gmd:locale>
   {% endif %}
   <gmd:spatialRepresentationInfo>
-    {% if record['spatial']['datatype'] == 'vector' %}
+    {% if record.get('spatial',{}).get('datatype','') == 'vector' %}
     <gmd:MD_VectorSpatialRepresentation>
       <gmd:topologyLevel>
         <gmd:MD_TopologyLevelCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopologyLevelCode" codeSpace="ISOTC211/19115" codeListValue="geometryOnly">geometryOnly</gmd:MD_TopologyLevelCode>

--- a/pygeometa/schemas/iso19139_2/main.j2
+++ b/pygeometa/schemas/iso19139_2/main.j2
@@ -41,9 +41,11 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>ISO 19115:2003</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  {% if record['metadata'].get('dataseturi') %}
   <gmd:dataSetURI>
     <gco:CharacterString>{{ record['metadata']['dataseturi']|e }}</gco:CharacterString>
   </gmd:dataSetURI>
+  {% endif %}
   {% if record['metadata']['language_alternate'] %}
   <gmd:locale>
     <gmd:PT_Locale id="locale-fr">
@@ -57,7 +59,7 @@
   </gmd:locale>
   {% endif %}
   <gmd:spatialRepresentationInfo>
-    {% if record['spatial']['datatype'] == 'vector' %}
+    {% if record.get('spatial',{}).get('datatype','') == 'vector' %}
     <gmd:MD_VectorSpatialRepresentation>
       <gmd:topologyLevel>
         <gmd:MD_TopologyLevelCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopologyLevelCode" codeSpace="ISOTC211/19115" codeListValue="geometryOnly">geometryOnly</gmd:MD_TopologyLevelCode>

--- a/pygeometa/schemas/iso19139_hnap/main.j2
+++ b/pygeometa/schemas/iso19139_hnap/main.j2
@@ -46,9 +46,11 @@
   <gmd:metadataStandardVersion>
     <gco:CharacterString>CAN/CGSB-171.100-2009</gco:CharacterString>
   </gmd:metadataStandardVersion>
+  {% if record['metadata'].get('dataseturi') %}
   <gmd:dataSetURI>
     <gco:CharacterString>{{ record['metadata']['dataseturi']|e }}</gco:CharacterString>
   </gmd:dataSetURI>
+  {% endif %}
   <gmd:locale>
     <gmd:PT_Locale id="fra">
       <gmd:languageCode>
@@ -63,7 +65,7 @@
     </gmd:PT_Locale>
   </gmd:locale>
   <gmd:spatialRepresentationInfo>
-    {% if record['spatial']['datatype'] == 'vector' %}
+    {% if record.get('spatial',{}).get('datatype','') == 'vector' %}
     <gmd:MD_VectorSpatialRepresentation>
       <gmd:topologyLevel>
         <gmd:MD_TopologyLevelCode codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopologyLevelCode" codeSpace="ISOTC211/19115" codeListValue="geometryOnly">geometryOnly</gmd:MD_TopologyLevelCode>


### PR DESCRIPTION
to prevent errors like: 

```
  File "/usr/local/lib/python3.12/dist-packages/pygeometa/schemas/iso19139/main.j2", line 60, in top-level template code
    {% if record['spatial']['datatype'] == 'vector' %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/jinja2/environment.py", line 468, in getitem
    return obj[argument]
           ~~~^^^^^^^^^^
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'spatial'
```