### PR TITLE
update MCF record lifecycle dates

### DIFF
--- a/docs/content/reference/mcf.md
+++ b/docs/content/reference/mcf.md
@@ -135,8 +135,24 @@ language_alternate|Optional|alternate language used for documenting metadata|en|
 charset|Mandatory|full name of the character coding standard used for the metadata set|utf8|ISO 19115:2003 Section B.2.1
 parentidentifier|Optional|file identifier of the metadata to which this metadata is a subset|11800c2c-e6b9-11df-b9ae-0014c2c33ebe|ISO 19115:2003 Section B.2.1
 hierarchylevel|Mandatory|level to which the metadata applies (must be one of 'series', 'software', 'featureType', 'model', 'collectionHardware', 'collectionSession', 'nonGeographicDataset', 'propertyType', 'fieldSession', 'dataset', 'service', 'attribute', 'attributeType', 'tile', 'feature', 'dimensionGroup'|dataset|ISO 19115:2003 Section B.2.1
-datestamp|Mandatory|date that the metadata was created, pygeometa supports specifying the $date$ or $datetime$ variable to update the date value at run time|2000-11-11 or 2000-01-12T11:11:11Z|ISO 19115:2003 Section B.2.1
 dataseturi|Optional|Uniformed Resource Identifier (URI) of the dataset to which the metadata applies|`urn:x-wmo:md:int.wmo.wis::http://geo.woudc.org/def/data/uv-radiation/uv-irradiance`|ISO 19115:2003 Section B.2.1
+
+#### `metadata.dates`
+
+`metadata.dates` sections (in the context of metadata record lifecycle) can have 1..n `dates` sections as required with the following object names/types:
+
+Property Name|Mandatory/Optional|Description|Example|Reference
+-------------|------------------|-----------|-------|---------:
+creation|Mandatory|record creation date|2000-09-01 or 2000-09-01T00:00:00Z|OGC API - Records - Part 1: Core, Subclause 7.2.2, Table 8
+revision|Optional|record update date|2000-09-01 or 2000-09-01T00:00:00Z|OGC API - Records - Part 1: Core, Subclause 7.2.2, Table 8
+
+```yaml
+metadata:
+    ...
+    dates:
+        creation: 2025-03-21
+        revision: 2026-11-25
+```
 
 ### `metadata.additional_identifiers`
 
@@ -183,13 +199,13 @@ browsegraphic|Optional|graphic that provides an illustration of the dataset|http
 
 #### `identification.dates`
 
-`identification.dates` sections can have 1..n `dates` sections as required with the following object names/types:
+`identification.dates` sections (in the context of data citation) can have 1..n `dates` sections as required with the following object names/types:
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-creation|Mandatory*|'creation' reference date for the cited resource, referring to when the resource was brought into existence, *: presence of creation or publication or revision is mandatory|2000-09-01 or 2000-09-01T00:00:00Z|ISO 19115:2003 Section B.3.2.4
-publication|Optional*|'publication' reference date for the cited resource, referring to when the resource was issued, *: presence of creation or publication or revision is mandatory|2000-09-01 or 2000-09-01T00:00:00Z|ISO 19115:2003 Section B.3.2.4
-revision|Optional*|'revision' reference date for the cited resource, referring to when the resource was examined or re-examined and improved or amended, *: presence of creation or publication or revision is mandatory|2000-09-01 or 2000-09-01T00:00:00Z|ISO 19115:2003 Section B.3.2.4
+creation|Optional|'creation' reference date for the cited resource, referring to when the resource was brought into existence, *: presence of creation or publication or revision is mandatory|2000-09-01 or 2000-09-01T00:00:00Z|ISO 19115:2003 Section B.3.2.4
+publication|Optional|'publication' reference date for the cited resource, referring to when the resource was issued, *: presence of creation or publication or revision is mandatory|2000-09-01 or 2000-09-01T00:00:00Z|ISO 19115:2003 Section B.3.2.4
+revision|Optional|'revision' reference date for the cited resource, referring to when the resource was examined or re-examined and improved or amended, *: presence of creation or publication or revision is mandatory|2000-09-01 or 2000-09-01T00:00:00Z|ISO 19115:2003 Section B.3.2.4
 
 ```yaml
 identification:

--- a/docs/content/reference/mcf.md
+++ b/docs/content/reference/mcf.md
@@ -1,6 +1,6 @@
 # Metadata Control File Reference
 
-Version: 1.0
+Version: 2.0
 
 ## Basic Concepts
 
@@ -123,7 +123,7 @@ Keyword|Description|Format|Example
 
 Property Name|Mandatory/Optional|Description|Example|Reference
 -------------|------------------|-----------|-------|---------:
-version|Mandatory|version of MCF format|1.0|pygeometa
+version|Mandatory|version of MCF format|2.0|pygeometa
 
 ### `metadata`
 

--- a/pygeometa/core.py
+++ b/pygeometa/core.py
@@ -234,7 +234,7 @@ def read_mcf(mcf: Union[dict, str]) -> dict:
     """
 
     mcf_dict = {}
-    mcf_versions = ['1.0']
+    mcf_versions = ['2.0']
 
     def __to_dict(mcf_object):
         """normalize mcf input into dict"""

--- a/pygeometa/core.py
+++ b/pygeometa/core.py
@@ -52,7 +52,6 @@ import logging
 import os
 import pathlib
 import re
-import traceback
 from typing import IO, Union
 from xml.dom import minidom
 
@@ -369,11 +368,9 @@ def import_metadata(schema: str, metadata: str) -> dict:
             error_message = f'Import not supported for {s}'
         except Exception as err:
             error_message = f'Import failed: {err}'
-            error_trace = traceback.format_exc()
 
     if error_message is not None:
         LOGGER.warning(error_message)
-        LOGGER.debug(error_trace)
 
     return content
 

--- a/pygeometa/pygeoapi_plugin.py
+++ b/pygeometa/pygeoapi_plugin.py
@@ -256,7 +256,7 @@ PROCESS_METADATA_VALIDATE = {
     },
     'example': {
         'inputs': {
-            'mcf': {'mcf': {'version': '1.0'}}
+            'mcf': {'mcf': {'version': '2.0'}}
         }
     }
 }
@@ -296,7 +296,7 @@ PROCESS_METADATA_GENERATE = {
     },
     'example': {
         'inputs': {
-            'mcf': {'mcf': {'version': '1.0'}},
+            'mcf': {'mcf': {'version': '2.0'}},
             'schema': 'oarec-record'
         }
     }

--- a/pygeometa/schemas/cwl/__init__.py
+++ b/pygeometa/schemas/cwl/__init__.py
@@ -112,7 +112,7 @@ class CWLOutputSchema(BaseOutputSchema):
 
         mcf['metadata']['identifier'] = wf['id']
         mcf['metadata']['hierarchylevel'] = 'application'
-        mcf['metadata']['datestamp'] = now
+        mcf['metadata']['dates']['creation'] = now
         mcf['identification']['title'] = wf['label']
         mcf['identification']['abstract'] = wf['doc']
 

--- a/pygeometa/schemas/iso19139/__init__.py
+++ b/pygeometa/schemas/iso19139/__init__.py
@@ -83,7 +83,9 @@ class ISO19139OutputSchema(BaseOutputSchema):
             'mcf': {
                 'version': '1.0',
             },
-            'metadata': {},
+            'metadata': {
+                'dates': {}
+            },
             'spatial': {},
             'identification': {},
             'contact': {},
@@ -100,7 +102,7 @@ class ISO19139OutputSchema(BaseOutputSchema):
         mcf['metadata']['identifier'] = m.identifier
 
         mcf['metadata']['hierarchylevel'] = m.hierarchy
-        mcf['metadata']['datestamp'] = m.datestamp
+        mcf['metadata']['dates']['creation'] = m.datestamp
 
         LOGGER.debug('Setting language')
         if m.language:

--- a/pygeometa/schemas/iso19139/main.j2
+++ b/pygeometa/schemas/iso19139/main.j2
@@ -28,7 +28,7 @@
   {% endif %}
   {% endfor %}
   <gmd:dateStamp>
-    {% set datestamp = record['metadata'].get('datestamp','')|normalize_datestring %}
+    {% set datestamp = record['metadata']['dates']['creation']|normalize_datestring %}
     {% if datestamp|length > 11 %}
     <gco:DateTime>{{ datestamp }}</gco:DateTime>
     {% else %}

--- a/pygeometa/schemas/iso19139_2/main.j2
+++ b/pygeometa/schemas/iso19139_2/main.j2
@@ -28,7 +28,7 @@
   {% endif %}
   {% endfor %}
   <gmd:dateStamp>
-    {% set datestamp = record['metadata']['datestamp']|normalize_datestring %}
+    {% set datestamp = record['metadata']['dates']['creation']|normalize_datestring %}
     {% if datestamp|length > 11 %}
     <gco:DateTime>{{ datestamp }}</gco:DateTime>
     {% else %}

--- a/pygeometa/schemas/iso19139_hnap/main.j2
+++ b/pygeometa/schemas/iso19139_hnap/main.j2
@@ -28,7 +28,7 @@
   {% endif %}
   {% endfor %}
   <gmd:dateStamp>
-    {% set datestamp = record['metadata']['datestamp']|normalize_datestring %}
+    {% set datestamp = record['metadata']['dates']['creation']|normalize_datestring %}
     {% if datestamp|length > 11 %}
     <gco:DateTime>{{ datestamp }}</gco:DateTime>
     {% else %}

--- a/pygeometa/schemas/mcf/core.yaml
+++ b/pygeometa/schemas/mcf/core.yaml
@@ -12,7 +12,7 @@ properties:
             version:
                 type: number
                 description: version of MCF format
-                const: 1.0
+                const: 2.0
         required:
             - version
     metadata:

--- a/pygeometa/schemas/mcf/core.yaml
+++ b/pygeometa/schemas/mcf/core.yaml
@@ -70,9 +70,18 @@ properties:
                     - tile
                     - feature
                     - dimensionGroup
-            datestamp:
-                $ref: '#/definitions/date_or_datetime_string'
-                description: date that the metadata was created, pygeometa supports specifying the `$date$` or `$datetime$` variable to update the date value at run time
+            dates:
+                type: object
+                description: record lifecycle dates
+                properties:
+                    creation:
+                        $ref: '#/definitions/date_or_datetime_string'
+                        format: string
+                    revision:
+                        $ref: '#/definitions/date_or_datetime_string'
+                        format: string
+                required:
+                    - creation
             dataseturi:
                 type: string
                 description: Uniform Resource Identifier (URI) of the dataset to which the metadata applies
@@ -81,7 +90,7 @@ properties:
             - language
             - charset
             - hierarchylevel
-            - datestamp
+            - dates
     spatial:
         type: object
         properties:
@@ -259,13 +268,13 @@ properties:
                 properties:
                     anyOf:
                         creation:
-                            type: '#/definitions/date_or_datetime_string'
+                            $ref: '#/definitions/date_or_datetime_string'
                             format: string
                         publication:
-                            type: '#/definitions/date_or_datetime_string'
+                            $ref: '#/definitions/date_or_datetime_string'
                             format: string
                         revision:
-                            type: '#/definitions/date_or_datetime_string'
+                            $ref: '#/definitions/date_or_datetime_string'
                             format: string
             extents:
                 type: object
@@ -358,7 +367,6 @@ properties:
             - rights
             - url
             - status
-            - dates
             - extents
             - keywords
     content_info:

--- a/pygeometa/schemas/ogcapi_records/__init__.py
+++ b/pygeometa/schemas/ogcapi_records/__init__.py
@@ -176,7 +176,7 @@ class OGCAPIRecordOutputSchema(BaseOutputSchema):
 
         LOGGER.debug('Checking for dates')
 
-        for key, value in mcf['identification']['dates'].items():
+        for key, value in mcf['metadata']['dates'].items():
             if key == 'creation':
                 record['properties']['created'] = generate_datetime(value)
             elif key == 'revision':

--- a/pygeometa/schemas/openaire/__init__.py
+++ b/pygeometa/schemas/openaire/__init__.py
@@ -86,7 +86,9 @@ class OpenAireOutputSchema(BaseOutputSchema):
             'mcf': {
                 'version': '1.0',
             },
-            'metadata': {},
+            'metadata': {
+                'dates': {}
+            },
             'identification': {},
             'contact': {}
         }
@@ -145,7 +147,8 @@ class OpenAireOutputSchema(BaseOutputSchema):
 
         date_of_collection = metadata_.get('dateOfCollection')
         if date_of_collection is not None:
-            mcf['metadata']['datestamp'] = metadata_.get('dateOfCollection')
+            mcf['metadata']['dates']['creation'] = \
+                metadata_.get('dateOfCollection')
 
         if main_instance_ is not None:
             urls = main_instance_.get('urls')
@@ -193,11 +196,10 @@ class OpenAireOutputSchema(BaseOutputSchema):
         e_date = metadata_.get('embargoEndDate')
         if p_date:
             dates_dict['publication'] = p_date
-            mcf['identification']['datestamp'] = [p_date]
         if e_date:
             dates_dict['embargoend'] = e_date
         if dates_dict:
-            mcf['identification']['dates'] = dates_dict
+            mcf['metadata']['dates'] = dates_dict
 
         subjects_ = metadata_.get('subjects')
         if isinstance(subjects_, dict):

--- a/pygeometa/schemas/wmo_cmp/main.j2
+++ b/pygeometa/schemas/wmo_cmp/main.j2
@@ -28,7 +28,7 @@
   {% endif %}
   {% endfor %}
   <gmd:dateStamp>
-    {% set datestamp = record['metadata']['datestamp']|normalize_datestring %}
+    {% set datestamp = record['metadata']['dates']['creation']|normalize_datestring %}
     {% if datestamp|length > 11 %}
     <gco:DateTime>{{ datestamp }}</gco:DateTime>
     {% else %}

--- a/pygeometa/schemas/wmo_wigos/main.j2
+++ b/pygeometa/schemas/wmo_wigos/main.j2
@@ -4,7 +4,7 @@
 <wmdr:WIGOSMetadataRecord gml:id="id_{{ record['metadata']['identifier'] }}" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:om="http://www.opengis.net/om/2.0" xmlns:wmdr="http://def.wmo.int/wmdr/2017" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://def.wmo.int/wmdr/2017 http://schemas.wmo.int/wmdr/1.0RC9/wmdr.xsd">
     <wmdr:headerInformation>
         <wmdr:Header>
-            <wmdr:fileDateTime>{{ record['metadata']['datestamp'].strftime('%Y-%m-%dT%H:%M:%SZ') }}</wmdr:fileDateTime>
+            <wmdr:fileDateTime>{{ record['metadata']['dates']['creation'].strftime('%Y-%m-%dT%H:%M:%SZ') }}</wmdr:fileDateTime>
             <wmdr:recordOwner>
                 {% set contact = record['contact']['record_owner'] %}
                 {% set contact_id = 'recordOwner' %}

--- a/sample-wmo-wigos.mcf.yml
+++ b/sample-wmo-wigos.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab

--- a/sample-wmo-wigos.mcf.yml
+++ b/sample-wmo-wigos.mcf.yml
@@ -6,7 +6,8 @@ metadata:
     language: en
     language_alternate: fr
     charset: utf8
-    datestamp: 2014-11-11T11:11:11Z
+    dates:
+        creation: 2014-11-11T11:11:11Z
 
 contact:
     main: &contact_main

--- a/sample.mcf.yml
+++ b/sample.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab

--- a/sample.mcf.yml
+++ b/sample.mcf.yml
@@ -15,7 +15,8 @@ metadata:
           scheme: http://doi.org
           type: source 
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/bad-version.mcf.yml
+++ b/tests/bad-version.mcf.yml
@@ -8,7 +8,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/base-metadata.mcf.yml
+++ b/tests/base-metadata.mcf.yml
@@ -1,2 +1,3 @@
 identifier: s1234
-datestamp: 2011-11-11
+dates:
+    creation: 2011-11-11

--- a/tests/broken-yaml.mcf.yml
+++ b/tests/broken-yaml.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab

--- a/tests/broken-yaml.mcf.yml
+++ b/tests/broken-yaml.mcf.yml
@@ -7,7 +7,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
     
 spatial:

--- a/tests/child.mcf.yml
+++ b/tests/child.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     base_mcf: base-metadata.mcf.yml

--- a/tests/dates-pre-1900.mcf.yml
+++ b/tests/dates-pre-1900.mcf.yml
@@ -8,7 +8,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/dates-pre-1900.mcf.yml
+++ b/tests/dates-pre-1900.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab

--- a/tests/deep-nest-child.mcf.yml
+++ b/tests/deep-nest-child.mcf.yml
@@ -10,7 +10,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/deep-nest-child.mcf.yml
+++ b/tests/deep-nest-child.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 base_mcf: deep-nest-parent.mcf.yml
 

--- a/tests/deep-nest-parent.mcf.yml
+++ b/tests/deep-nest-parent.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 base_mcf: contact.mcf.yml
 

--- a/tests/deep-nest-parent.mcf.yml
+++ b/tests/deep-nest-parent.mcf.yml
@@ -10,7 +10,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/missing-version.mcf.yml
+++ b/tests/missing-version.mcf.yml
@@ -5,7 +5,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/nil-identification-language.mcf.yml
+++ b/tests/nil-identification-language.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab

--- a/tests/nil-identification-language.mcf.yml
+++ b/tests/nil-identification-language.mcf.yml
@@ -8,7 +8,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: $date$
+    dates:
+        creation: $date$
     dataseturi: http://some/minted/uri
 
 spatial:

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -128,7 +128,7 @@ class PygeometaTest(unittest.TestCase):
 
         mcf = read_mcf(get_abspath('../sample.mcf.yml'))
         self.assertIsInstance(mcf['identification']['dates'], dict,
-                              'Expected list')
+                              'Expected dict')
         self.assertIsInstance(mcf['identification']['keywords'], dict,
                               'Expected dict')
         self.assertIsInstance(mcf['identification']['topiccategory'], list,
@@ -296,9 +296,9 @@ class PygeometaTest(unittest.TestCase):
                          'http://example.org/waf',
                          'Expected specific distribution url')
 
-        self.assertEqual(mcf['metadata']['datestamp'],
+        self.assertEqual(mcf['metadata']['dates']['creation'],
                          datetime.date(2011, 11, 11),
-                         'Expected specific metadata datestamp')
+                         'Expected specific metadata creation date')
 
         self.assertIsInstance(mcf, dict, 'Expected dict')
 

--- a/tests/sample-child.mcf.yml
+++ b/tests/sample-child.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     base_mcf: base-metadata.mcf.yml

--- a/tests/unilingual.mcf.yml
+++ b/tests/unilingual.mcf.yml
@@ -1,5 +1,5 @@
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: 3f342f64-9348-11df-ba6a-0014c2c00eab

--- a/tests/unilingual.mcf.yml
+++ b/tests/unilingual.mcf.yml
@@ -7,7 +7,8 @@ metadata:
     charset: utf8
     parentidentifier: someparentid
     hierarchylevel: dataset
-    datestamp: 2014-11-11
+    dates:
+        creation: 2014-11-11
     dataseturi: http://some/minted/uri
     
 spatial:


### PR DESCRIPTION
This PR updates pygeometa's record lifecycle support by moving from `metadata.datestamp` to `metadata.dates`, where `metadata.dates` is the exact same design pattern as `identification.dates`, but focused on record lifecycle (vs. `identification.dates` which is based on citation).

**Note that this is a breaking change,** and that the 0.20.0 release can be used safely until users migrate accordingly against master or when 0.21.0 is released.  Summary of changes are as follows:

- `metadata.datestamp` is removed (BREAKING)
- `identification.dates` is now optional (BREAKING)
- `metadata.dates.creation` is added and mandatory (BREAKING)
- `metadata.dates.revision` is added and optional
