### PR TITLE
fix generate_datetime helper

### DIFF
--- a/pygeometa/helpers.py
+++ b/pygeometa/helpers.py
@@ -104,6 +104,7 @@ def generate_datetime(date_value: str) -> str:
     :returns: `str` of date-time value
     """
 
+    format_ = None
     value = None
 
     if isinstance(date_value, str) and date_value != 'None':
@@ -118,8 +119,9 @@ def generate_datetime(date_value: str) -> str:
             LOGGER.debug(msg)
             format_ = '%Y-%m-%dT%H:%M:%S'
 
-        LOGGER.debug('date type found; expanding to date-time')
-        value = datetime.strptime(date_value, format_).strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
+        if format_ is not None:
+            LOGGER.debug('date type found; expanding to date-time')
+            value = datetime.strptime(date_value, format_).strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
 
     elif isinstance(date_value, int) and len(str(date_value)) == 4:
         date_value2 = str(date_value)

--- a/pygeometa/helpers.py
+++ b/pygeometa/helpers.py
@@ -122,6 +122,8 @@ def generate_datetime(date_value: str) -> str:
         if format_ is not None:
             LOGGER.debug('date type found; expanding to date-time')
             value = datetime.strptime(date_value, format_).strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
+        else:
+            value = date_value
 
     elif isinstance(date_value, int) and len(str(date_value)) == 4:
         date_value2 = str(date_value)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -59,7 +59,7 @@ from pygeometa.core import (read_mcf, pretty_print, render_j2_template,
                             prune_transfer_option, MCFReadError,
                             MCFValidationError, SCHEMAS, transform_metadata,
                             validate_mcf)
-from pygeometa.helpers import json_dumps
+from pygeometa.helpers import generate_datetime, json_dumps
 from pygeometa.schemas import (get_supported_schemas, InvalidSchemaError,
                                load_schema)
 from pygeometa.schemas.iso19139 import ISO19139OutputSchema
@@ -548,6 +548,23 @@ class PygeometaTest(unittest.TestCase):
             "polygon": "2 1 4 1 2 3 4 3 2 1"
         }
         self.assertEqual(_get_box_from_coords(geo3), [1, 2, 3, 4])
+
+    def test_generate_datetime(self):
+        """Test pygeometa.helpers:generate_datetime"""
+
+        self.assertEqual(generate_datetime('2026'), '2026-01-01T00:00:00Z')
+        self.assertEqual(generate_datetime('2026-10'), '2026-10-01T00:00:00Z')
+        self.assertEqual(generate_datetime('2026-10-30'),
+                         '2026-10-30T00:00:00Z')
+        self.assertEqual(generate_datetime('2026-10-30T00:12:21'),
+                         '2026-10-30T00:12:21Z')
+        self.assertEqual(generate_datetime(2026), '2026-01-01T00:00:00Z')
+        self.assertEqual(generate_datetime(datetime.datetime(2026, 10, 30)),
+                         '2026-10-30T00:00:00Z')
+        self.assertEqual(generate_datetime(datetime.datetime(2026, 10, 30, 11, 11, 11)),  # noqa
+                         '2026-10-30T11:11:11Z')
+        self.assertEqual(len(generate_datetime(None)), 20)
+        self.assertEqual(len(generate_datetime('None')), 20)
 
 
 def get_abspath(filepath):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -558,6 +558,8 @@ class PygeometaTest(unittest.TestCase):
                          '2026-10-30T00:00:00Z')
         self.assertEqual(generate_datetime('2026-10-30T00:12:21'),
                          '2026-10-30T00:12:21Z')
+        self.assertEqual(generate_datetime('2026-10-30T00:12:21Z'),
+                         '2026-10-30T00:12:21Z')
         self.assertEqual(generate_datetime(2026), '2026-01-01T00:00:00Z')
         self.assertEqual(generate_datetime(datetime.datetime(2026, 10, 30)),
                          '2026-10-30T00:00:00Z')


### PR DESCRIPTION
This PR fixes an edge case in `pygeometa.schemas.helpers:generate_datetime`, as well as adds accompanying tests.