### PR TITLE
www.epsg-registry.org replaced with epsg.io.  the www address doesnt …

### DIFF
--- a/pygeometa/schemas/iso19139/main.j2
+++ b/pygeometa/schemas/iso19139/main.j2
@@ -103,7 +103,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://epsg.io</gmd:URL>
+                            <gmd:URL>http://epsg.org</gmd:URL>
                           </gmd:linkage>
                         </gmd:CI_OnlineResource>
                       </gmd:onlineResource>

--- a/pygeometa/schemas/iso19139/main.j2
+++ b/pygeometa/schemas/iso19139/main.j2
@@ -103,7 +103,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                            <gmd:URL>http://epsg.io</gmd:URL>
                           </gmd:linkage>
                         </gmd:CI_OnlineResource>
                       </gmd:onlineResource>

--- a/pygeometa/schemas/iso19139_2/main.j2
+++ b/pygeometa/schemas/iso19139_2/main.j2
@@ -103,7 +103,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://epsg.io</gmd:URL>
+                            <gmd:URL>http://epsg.org</gmd:URL>
                           </gmd:linkage>
                         </gmd:CI_OnlineResource>
                       </gmd:onlineResource>

--- a/pygeometa/schemas/iso19139_2/main.j2
+++ b/pygeometa/schemas/iso19139_2/main.j2
@@ -103,7 +103,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                            <gmd:URL>http://epsg.io</gmd:URL>
                           </gmd:linkage>
                         </gmd:CI_OnlineResource>
                       </gmd:onlineResource>

--- a/pygeometa/schemas/iso19139_hnap/main.j2
+++ b/pygeometa/schemas/iso19139_hnap/main.j2
@@ -119,7 +119,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                            <gmd:URL>http://epsg.io</gmd:URL>
                           </gmd:linkage>
                           <gmd:protocol>
                             <gco:CharacterString>WWW:LINK</gco:CharacterString>

--- a/pygeometa/schemas/iso19139_hnap/main.j2
+++ b/pygeometa/schemas/iso19139_hnap/main.j2
@@ -119,7 +119,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://epsg.io</gmd:URL>
+                            <gmd:URL>http://epsg.org</gmd:URL>
                           </gmd:linkage>
                           <gmd:protocol>
                             <gco:CharacterString>WWW:LINK</gco:CharacterString>

--- a/pygeometa/schemas/wmo_cmp/main.j2
+++ b/pygeometa/schemas/wmo_cmp/main.j2
@@ -101,7 +101,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://epsg.io</gmd:URL>
+                            <gmd:URL>http://epsg.org</gmd:URL>
                           </gmd:linkage>
                         </gmd:CI_OnlineResource>
                       </gmd:onlineResource>

--- a/pygeometa/schemas/wmo_cmp/main.j2
+++ b/pygeometa/schemas/wmo_cmp/main.j2
@@ -101,7 +101,7 @@
                       <gmd:onlineResource>
                         <gmd:CI_OnlineResource>
                           <gmd:linkage>
-                            <gmd:URL>http://www.epsg-registry.org</gmd:URL>
+                            <gmd:URL>http://epsg.io</gmd:URL>
                           </gmd:linkage>
                         </gmd:CI_OnlineResource>
                       </gmd:onlineResource>


### PR DESCRIPTION
Solves issue 338 [(https://github.com/geopython/pygeometa/issues/338)](https://github.com/geopython/pygeometa/issues/338)]